### PR TITLE
Add most externs and support methods used by tna_simple_switch

### DIFF
--- a/targets/tofino/base/expression_resolver.cpp
+++ b/targets/tofino/base/expression_resolver.cpp
@@ -25,632 +25,629 @@ const IR::Expression *TofinoBaseExpressionResolver::processTable(const IR::P4Tab
 // Provides implementations of Tofino externs.
 namespace TofinoBaseExterns {
 
-const ExternMethodImpls EXTERN_METHOD_IMPLS({
-    // -----------------------------------------------------------------------------
-    // CHECKSUM
-    // -----------------------------------------------------------------------------
-    // Tofino checksum engine can verify the checksums for header-only checksums
-    // and calculate the residual (checksum minus the header field
-    // contribution) for checksums that include the payload.
-    // Checksum engine only supports 16-bit ones' complement checksums, also known
-    // as csum16 or internet checksum.
-    // -----------------------------------------------------------------------------
-    /// Add data to checksum.
-    /// @param data : List of fields to be added to checksum calculation. The
-    /// data must be byte aligned.
-    {"Checksum.add",
-     {"data"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         // We do not calculate the checksum for now.
-         return nullptr;
-     }},
-    /// Subtract data from existing checksum.
-    /// @param data : List of fields to be subtracted from the checksum. The
-    /// data must be byte aligned.
-    {"Checksum.subtract",
-     {"data"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// Subtract data from existing checksum.
-    /// @param data : List of fields to be subtracted from the checksum. The
-    /// data must be byte aligned.
-    {"Checksum.verify",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-        // We do not calculate the checksum for now and instead use a dummy.
-         auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
-                              externInfo.methodName + "_" +
-                              std::to_string(externInfo.originalCall.clone_id);
-         const auto *hashCalc =
-             ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
-         return new IR::Equ(hashCalc, IR::getConstant(IR::getBitType(16), 0xffff));
-     }},
-    /// Subtract all header fields after the current state and
-    /// return the calculated checksum value.
-    /// Marks the end position for residual checksum header.
-    /// All header fields extracted after will be automatically subtracted.
-    /// @param residual: The calculated checksum value for added fields.
-    {"Checksum.subtract_all_and_deposit",
-     {"residual"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// Get the calculated checksum value.
-    /// @return : The calculated checksum value for added fields.
-    {"Checksum.get",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// Calculate the checksum for a  given list of fields.
-    /// @param data : List of fields contributing to the checksum value.
-    /// @param zeros_as_ones : encode all-zeros value as all-ones.
-    {"Checksum.update",
-     {"data"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         // We do not calculate the checksum for now and instead use a dummy.
-         auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
-                              externInfo.methodName + "_" +
-                              std::to_string(externInfo.originalCall.clone_id);
-         const auto hashCalc =
-             ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
-         return hashCalc;
-     }},
-    {"Checksum.update",
-     {"data", "zeros_as_ones"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         // We do not calculate the checksum for now and instead use a dummy.
-         auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
-                              externInfo.methodName + "_" +
-                              std::to_string(externInfo.originalCall.clone_id);
-         const auto hashCalc =
-             ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
-         return hashCalc;
-     }},
+const ExternMethodImpls EXTERN_METHOD_IMPLS(
+    {// -----------------------------------------------------------------------------
+     // CHECKSUM
+     // -----------------------------------------------------------------------------
+     // Tofino checksum engine can verify the checksums for header-only checksums
+     // and calculate the residual (checksum minus the header field
+     // contribution) for checksums that include the payload.
+     // Checksum engine only supports 16-bit ones' complement checksums, also known
+     // as csum16 or internet checksum.
+     // -----------------------------------------------------------------------------
+     /// Add data to checksum.
+     /// @param data : List of fields to be added to checksum calculation. The
+     /// data must be byte aligned.
+     {"Checksum.add",
+      {"data"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          // We do not calculate the checksum for now.
+          return nullptr;
+      }},
+     /// Subtract data from existing checksum.
+     /// @param data : List of fields to be subtracted from the checksum. The
+     /// data must be byte aligned.
+     {"Checksum.subtract",
+      {"data"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// Subtract data from existing checksum.
+     /// @param data : List of fields to be subtracted from the checksum. The
+     /// data must be byte aligned.
+     {"Checksum.verify",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          // We do not calculate the checksum for now and instead use a dummy.
+          auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
+                               externInfo.methodName + "_" +
+                               std::to_string(externInfo.originalCall.clone_id);
+          const auto *hashCalc =
+              ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
+          return new IR::Equ(hashCalc, IR::getConstant(IR::getBitType(16), 0xffff));
+      }},
+     /// Subtract all header fields after the current state and
+     /// return the calculated checksum value.
+     /// Marks the end position for residual checksum header.
+     /// All header fields extracted after will be automatically subtracted.
+     /// @param residual: The calculated checksum value for added fields.
+     {"Checksum.subtract_all_and_deposit",
+      {"residual"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// Get the calculated checksum value.
+     /// @return : The calculated checksum value for added fields.
+     {"Checksum.get",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// Calculate the checksum for a  given list of fields.
+     /// @param data : List of fields contributing to the checksum value.
+     /// @param zeros_as_ones : encode all-zeros value as all-ones.
+     {"Checksum.update",
+      {"data"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          // We do not calculate the checksum for now and instead use a dummy.
+          auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
+                               externInfo.methodName + "_" +
+                               std::to_string(externInfo.originalCall.clone_id);
+          const auto hashCalc =
+              ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
+          return hashCalc;
+      }},
+     {"Checksum.update",
+      {"data", "zeros_as_ones"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          // We do not calculate the checksum for now and instead use a dummy.
+          auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
+                               externInfo.methodName + "_" +
+                               std::to_string(externInfo.originalCall.clone_id);
+          const auto hashCalc =
+              ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
+          return hashCalc;
+      }},
 
-    // -----------------------------------------------------------------------------
-    // PARSER COUNTER
-    // -----------------------------------------------------------------------------
-    // Tofino parser counter can be used to extract header stacks or headers with
-    // variable length. Tofino has a single 8-bit signed counter that can be
-    // initialized with an immediate value or a header field.
-    // -----------------------------------------------------------------------------
-    /// Load the counter with an immediate value or a header field.
-    {"ParserCounter.set",
-     {"value"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// Load the counter with a header field.
-    /// @param max : Maximum permitted value for counter (pre rotate/mask/add).
-    /// @param rotate : Right rotate (circular) the source field by this number of bits.
-    /// @param mask : Mask the rotated source field by 2 ^ (mask + 1) - 1.
-    /// @param add : Constant to add to the rotated and masked lookup field.
-    {"ParserCounter.set",
-     {"field", "max", "rotate", "mask", "add"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// @return true if counter value is zero.
-    {"ParserCounter.is_zero",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// @return true if counter value is negative.
-    {"ParserCounter.is_negative",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// Add an immediate value to the parser counter.
-    /// @param value : Constant to add to the counter.
-    {"ParserCounter.increment",
-     {"value"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    /// Subtract an immediate value from the parser counter.
-    /// @param value : Constant to subtract from the counter.
-    {"ParserCounter.decrement",
-     {"value"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     // PARSER COUNTER
+     // -----------------------------------------------------------------------------
+     // Tofino parser counter can be used to extract header stacks or headers with
+     // variable length. Tofino has a single 8-bit signed counter that can be
+     // initialized with an immediate value or a header field.
+     // -----------------------------------------------------------------------------
+     /// Load the counter with an immediate value or a header field.
+     {"ParserCounter.set",
+      {"value"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// Load the counter with a header field.
+     /// @param max : Maximum permitted value for counter (pre rotate/mask/add).
+     /// @param rotate : Right rotate (circular) the source field by this number of bits.
+     /// @param mask : Mask the rotated source field by 2 ^ (mask + 1) - 1.
+     /// @param add : Constant to add to the rotated and masked lookup field.
+     {"ParserCounter.set",
+      {"field", "max", "rotate", "mask", "add"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// @return true if counter value is zero.
+     {"ParserCounter.is_zero",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// @return true if counter value is negative.
+     {"ParserCounter.is_negative",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// Add an immediate value to the parser counter.
+     /// @param value : Constant to add to the counter.
+     {"ParserCounter.increment",
+      {"value"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     /// Subtract an immediate value from the parser counter.
+     /// @param value : Constant to subtract from the counter.
+     {"ParserCounter.decrement",
+      {"value"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    // PARSER PRIORITY
-    // -----------------------------------------------------------------------------
-    // Tofino ingress parser compare the priority with a configurable!!! threshold
-    // to determine to whether drop the packet if the input buffer is congested.
-    // Egress parser does not perform any dropping.
-    // -----------------------------------------------------------------------------
-    /// Set a new priority for the packet.
-    /// param prio : parser priority for the parsed packet.
-    {"ParserPriority.set",
-     {"prio"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     // PARSER PRIORITY
+     // -----------------------------------------------------------------------------
+     // Tofino ingress parser compare the priority with a configurable!!! threshold
+     // to determine to whether drop the packet if the input buffer is congested.
+     // Egress parser does not perform any dropping.
+     // -----------------------------------------------------------------------------
+     /// Set a new priority for the packet.
+     /// param prio : parser priority for the parsed packet.
+     {"ParserPriority.set",
+      {"prio"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    // HASH ENGINE
-    // -----------------------------------------------------------------------------
-    // TODO: CRCPolynomial
-    // extern CRCPolynomial<T> {
-    //     CRCPolynomial(T coeff, bool reversed, bool msb, bool extended, T init, T xor);
-    // }
-    {"Hash.get",
-     {"data"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    /// Random number generator.
-    /// Return a random number with uniform distribution.
-    /// @return : random number between 0 and 2**W - 1
-    // -----------------------------------------------------------------------------
-    {"Random.get",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     // HASH ENGINE
+     // -----------------------------------------------------------------------------
+     // TODO: CRCPolynomial
+     // extern CRCPolynomial<T> {
+     //     CRCPolynomial(T coeff, bool reversed, bool msb, bool extended, T init, T xor);
+     // }
+     {"Hash.get",
+      {"data"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     /// Random number generator.
+     /// Return a random number with uniform distribution.
+     /// @return : random number between 0 and 2**W - 1
+     // -----------------------------------------------------------------------------
+     {"Random.get",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    // EXTERN FUNCTIONS
-    // -----------------------------------------------------------------------------
-    {"*method.max",
-     {"t1", "t2"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.min",
-     {"t1", "t2"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.funnel_shift_right",
-     {"dst", "src1", "src2", "shift_amount"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.invalidate",
-     {"field"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.is_validated",
-     {"field"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.port_metadata_unpack",
-     {"pkt"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.sizeInBits",
-     {"h"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"*method.sizeInBytes",
-     {"h"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     // EXTERN FUNCTIONS
+     // -----------------------------------------------------------------------------
+     {"*method.max",
+      {"t1", "t2"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.min",
+      {"t1", "t2"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.funnel_shift_right",
+      {"dst", "src1", "src2", "shift_amount"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.invalidate",
+      {"field"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.is_validated",
+      {"field"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.port_metadata_unpack",
+      {"pkt"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.sizeInBits",
+      {"h"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"*method.sizeInBytes",
+      {"h"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// Counter
-    /// Indexed counter with `size’ independent counter values.
-    // -----------------------------------------------------------------------------
-    // TODO: Count currently has no effect in the symbolic interpreter.
-    {"Counter.count",
-     {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
-    {"Counter.count",
-     {"index", "adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
-    /// DirectCounter
-    /// Increment the counter value.
-    /// @param adjust_byte_count : optional parameter indicating value to be
-    //                             subtracted from counter value.
-    // TODO: Count currently has no effect in the symbolic interpreter.
-    {"DirectCounter.count",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
-    {"DirectCounter.count",
-     {"adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
+     // -----------------------------------------------------------------------------
+     /// Counter
+     /// Indexed counter with `size’ independent counter values.
+     // -----------------------------------------------------------------------------
+     // TODO: Count currently has no effect in the symbolic interpreter.
+     {"Counter.count",
+      {"index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
+     {"Counter.count",
+      {"index", "adjust_byte_count"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
+     /// DirectCounter
+     /// Increment the counter value.
+     /// @param adjust_byte_count : optional parameter indicating value to be
+     //                             subtracted from counter value.
+     // TODO: Count currently has no effect in the symbolic interpreter.
+     {"DirectCounter.count",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
+     {"DirectCounter.count",
+      {"adjust_byte_count"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
 
-    // -----------------------------------------------------------------------------
-    /// Meter
-    // -----------------------------------------------------------------------------
-    {"Meter.execute",
-     {"index", "color"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"Meter.execute",
-     {"index", "color", "adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"Meter.execute",
-     {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"Meter.execute",
-     {"index", "adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// Meter
+     // -----------------------------------------------------------------------------
+     {"Meter.execute",
+      {"index", "color"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"Meter.execute",
+      {"index", "color", "adjust_byte_count"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"Meter.execute",
+      {"index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"Meter.execute",
+      {"index", "adjust_byte_count"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// Direct meter.
-    // -----------------------------------------------------------------------------
-    {"DirectMeter.execute",
-     {"color"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"DirectMeter.execute",
-     {"color", "adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"DirectMeter.execute",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"DirectMeter.execute",
-     {"adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// Direct meter.
+     // -----------------------------------------------------------------------------
+     {"DirectMeter.execute",
+      {"color"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"DirectMeter.execute",
+      {"color", "adjust_byte_count"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"DirectMeter.execute",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"DirectMeter.execute",
+      {"adjust_byte_count"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// LPF
-    // -----------------------------------------------------------------------------
-    {"Lpf.execute",
-     {"val", "index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// LPF
+     // -----------------------------------------------------------------------------
+     {"Lpf.execute",
+      {"val", "index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// Direct LPF
-    // -----------------------------------------------------------------------------
-    {"DirectLpf.execute",
-     {"val"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// Direct LPF
+     // -----------------------------------------------------------------------------
+     {"DirectLpf.execute",
+      {"val"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// WRED
-    // -----------------------------------------------------------------------------
-    {"Wred.execute",
-     {"val", "index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// WRED
+     // -----------------------------------------------------------------------------
+     {"Wred.execute",
+      {"val", "index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// Direct WRED
-    // -----------------------------------------------------------------------------
-    {"DirectWred.execute",
-     {"val"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// Direct WRED
+     // -----------------------------------------------------------------------------
+     {"DirectWred.execute",
+      {"val"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// Register
-    /// Return the value of register at specified index.
-    // -----------------------------------------------------------------------------
-    {"Register.read",
-     {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    /// Write value to register at specified index.
-    // -----------------------------------------------------------------------------
-    {"Register.write",
-     {"index", "value"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// Register
+     /// Return the value of register at specified index.
+     // -----------------------------------------------------------------------------
+     {"Register.read",
+      {"index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     /// Write value to register at specified index.
+     // -----------------------------------------------------------------------------
+     {"Register.write",
+      {"index", "value"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// DirectRegister
-    /// Return the value of the direct register.
-    // -----------------------------------------------------------------------------
-    {"DirectRegister.read",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    /// Write value to a direct register.
-    // -----------------------------------------------------------------------------
-    {"DirectRegister.read",
-     {"value"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// DirectRegister
+     /// Return the value of the direct register.
+     // -----------------------------------------------------------------------------
+     {"DirectRegister.read",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     /// Write value to a direct register.
+     // -----------------------------------------------------------------------------
+     {"DirectRegister.read",
+      {"value"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// Return the value of the parameter.
-    // -----------------------------------------------------------------------------
-    {"RegisterParam.read",
-     {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// Return the value of the parameter.
+     // -----------------------------------------------------------------------------
+     {"RegisterParam.read",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// MathUnit
-    // -----------------------------------------------------------------------------
-    {"MathUnit.execute",
-     {"x"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// MathUnit
+     // -----------------------------------------------------------------------------
+     {"MathUnit.execute",
+      {"x"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// RegisterAction
-    // This is implemented using an experimental feature in p4c and subject to
-    // change. See https://github.com/p4lang/p4-spec/issues/561 
-    // U execute(in I index) {
-    //     U rv;
-    //     T value = reg.read(index);
-    //     apply(value, rv);
-    //     reg.write(index, value);
-    //     return rv;
-    // }
-    // -----------------------------------------------------------------------------
-    {"RegisterAction.execute",
-     {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    // Apply the implemented abstract method using an index that increments each
-    // time. This method is useful for stateful logging.
-    // -----------------------------------------------------------------------------
-    {"RegisterAction.execute_log",
-     {""},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    // Abstract method that needs to be implemented when RegisterAction is
-    // instantiated.
-    // @param value : register value.
-    // @param rv : return value.
-    // -----------------------------------------------------------------------------
-    {"RegisterAction.apply",
-     {"value", "rv"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"RegisterAction.predicate",
-     {"cmplo", "cmphi"}, // TODO: the two arguments are both optional
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    
-    // -----------------------------------------------------------------------------
-    // DirectRegisterAction
-    //
-    // U execute() {
-    //     U rv;
-    //     T value = reg.read();
-    //     apply(value, rv);
-    //     reg.write(value);
-    //     return rv;
-    // }
-    // -----------------------------------------------------------------------------
-    {"DirectRegisterAction.execute",
-     {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    // DirectRegisterAction.apply
-    // -----------------------------------------------------------------------------
-    {"DirectRegisterAction.apply",
-     {"value", "rv"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    // DirectRegisterAction.predicate
-    // -----------------------------------------------------------------------------
-    {"DirectRegisterAction.predicate",
-     {"cmplo", "cmphi"}, // TODO: the two arguments are both optional
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     /// RegisterAction
+     // This is implemented using an experimental feature in p4c and subject to
+     // change. See https://github.com/p4lang/p4-spec/issues/561
+     // U execute(in I index) {
+     //     U rv;
+     //     T value = reg.read(index);
+     //     apply(value, rv);
+     //     reg.write(index, value);
+     //     return rv;
+     // }
+     // -----------------------------------------------------------------------------
+     {"RegisterAction.execute",
+      {"index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     // Apply the implemented abstract method using an index that increments each
+     // time. This method is useful for stateful logging.
+     // -----------------------------------------------------------------------------
+     {"RegisterAction.execute_log",
+      {""},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     // Abstract method that needs to be implemented when RegisterAction is
+     // instantiated.
+     // @param value : register value.
+     // @param rv : return value.
+     // -----------------------------------------------------------------------------
+     {"RegisterAction.apply",
+      {"value", "rv"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"RegisterAction.predicate",
+      {"cmplo", "cmphi"},  // TODO: the two arguments are both optional
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    /// SelectorAction
-    // -----------------------------------------------------------------------------
-    {"SelectorAction.execute",
-     {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    {"SelectorAction.apply",
-     {"value", "rv"}, // TODO: argument `rv` is both optional
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    
-    // -----------------------------------------------------------------------------
-    // Tofino supports mirroring both at the ingress and egress. Ingress deparser
-    // creates a copy of the original ingress packet and prepends the mirror header.
-    // Egress deparser first constructs the output packet and then prepends the
-    // mirror header.
-    // -----------------------------------------------------------------------------
-    /// Mirror the packet.
-    // -----------------------------------------------------------------------------
-    {"Mirror.emit",
-     {"session_id"}, 
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    /// Write @hdr into the ingress/egress mirror buffer.
-    /// @param hdr : T can be a header type.
-    // -----------------------------------------------------------------------------
-    {"Mirror.emit",
-     {"session_id", "hdr"}, 
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    
-    // -----------------------------------------------------------------------------
-    // Tofino supports packet resubmission at the end of ingress pipeline. When
-    // a packet is resubmitted, the original packet reference and some limited
-    // amount of metadata (64 bits) are passed back to the packet’s original
-    // ingress buffer, where the packet is enqueued again.
-    // -----------------------------------------------------------------------------
-    /// Resubmit the packet.
-    // -----------------------------------------------------------------------------
-    {"Resubmit.emit",
-     {}, 
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
-    // -----------------------------------------------------------------------------
-    /// Resubmit the packet and prepend it with @hdr.
-    /// @param hdr : T can be a header type.
-    // -----------------------------------------------------------------------------
-    {"Resubmit.emit",
-     {"hdr"}, 
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     // -----------------------------------------------------------------------------
+     // DirectRegisterAction
+     //
+     // U execute() {
+     //     U rv;
+     //     T value = reg.read();
+     //     apply(value, rv);
+     //     reg.write(value);
+     //     return rv;
+     // }
+     // -----------------------------------------------------------------------------
+     {"DirectRegisterAction.execute",
+      {"index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     // DirectRegisterAction.apply
+     // -----------------------------------------------------------------------------
+     {"DirectRegisterAction.apply",
+      {"value", "rv"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     // DirectRegisterAction.predicate
+     // -----------------------------------------------------------------------------
+     {"DirectRegisterAction.predicate",
+      {"cmplo", "cmphi"},  // TODO: the two arguments are both optional
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
 
-    // -----------------------------------------------------------------------------
-    // Digest
-    // -----------------------------------------------------------------------------
-    {"Digest.pack",
-     {"data"}, 
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }}
-});
+     // -----------------------------------------------------------------------------
+     /// SelectorAction
+     // -----------------------------------------------------------------------------
+     {"SelectorAction.execute",
+      {"index"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     {"SelectorAction.apply",
+      {"value", "rv"},  // TODO: argument `rv` is both optional
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+
+     // -----------------------------------------------------------------------------
+     // Tofino supports mirroring both at the ingress and egress. Ingress deparser
+     // creates a copy of the original ingress packet and prepends the mirror header.
+     // Egress deparser first constructs the output packet and then prepends the
+     // mirror header.
+     // -----------------------------------------------------------------------------
+     /// Mirror the packet.
+     // -----------------------------------------------------------------------------
+     {"Mirror.emit",
+      {"session_id"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     /// Write @hdr into the ingress/egress mirror buffer.
+     /// @param hdr : T can be a header type.
+     // -----------------------------------------------------------------------------
+     {"Mirror.emit",
+      {"session_id", "hdr"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+
+     // -----------------------------------------------------------------------------
+     // Tofino supports packet resubmission at the end of ingress pipeline. When
+     // a packet is resubmitted, the original packet reference and some limited
+     // amount of metadata (64 bits) are passed back to the packet’s original
+     // ingress buffer, where the packet is enqueued again.
+     // -----------------------------------------------------------------------------
+     /// Resubmit the packet.
+     // -----------------------------------------------------------------------------
+     {"Resubmit.emit",
+      {},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+     // -----------------------------------------------------------------------------
+     /// Resubmit the packet and prepend it with @hdr.
+     /// @param hdr : T can be a header type.
+     // -----------------------------------------------------------------------------
+     {"Resubmit.emit",
+      {"hdr"},
+      [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }},
+
+     // -----------------------------------------------------------------------------
+     // Digest
+     // -----------------------------------------------------------------------------
+     {"Digest.pack", {"data"}, [](const ExternMethodImpls::ExternInfo &externInfo) {
+          P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                            externInfo.externObjectRef.toString(), externInfo.methodName);
+          return nullptr;
+      }}});
 }  // namespace TofinoBaseExterns
 
 const IR::Expression *TofinoBaseExpressionResolver::processExtern(

--- a/targets/tofino/base/expression_resolver.cpp
+++ b/targets/tofino/base/expression_resolver.cpp
@@ -41,8 +41,7 @@ const ExternMethodImpls EXTERN_METHOD_IMPLS({
     {"Checksum.add",
      {"data"},
      [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         // We do not calculate the checksum for now.
          return nullptr;
      }},
     /// Subtract data from existing checksum.
@@ -61,9 +60,13 @@ const ExternMethodImpls EXTERN_METHOD_IMPLS({
     {"Checksum.verify",
      {},
      [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
+        // We do not calculate the checksum for now and instead use a dummy.
+         auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
+                              externInfo.methodName + "_" +
+                              std::to_string(externInfo.originalCall.clone_id);
+         const auto *hashCalc =
+             ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
+         return new IR::Equ(hashCalc, IR::getConstant(IR::getBitType(16), 0xffff));
      }},
     /// Subtract all header fields after the current state and
     /// return the calculated checksum value.
@@ -92,16 +95,24 @@ const ExternMethodImpls EXTERN_METHOD_IMPLS({
     {"Checksum.update",
      {"data"},
      [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
+         // We do not calculate the checksum for now and instead use a dummy.
+         auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
+                              externInfo.methodName + "_" +
+                              std::to_string(externInfo.originalCall.clone_id);
+         const auto hashCalc =
+             ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
+         return hashCalc;
      }},
     {"Checksum.update",
      {"data", "zeros_as_ones"},
      [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
+         // We do not calculate the checksum for now and instead use a dummy.
+         auto checksumLabel = externInfo.externObjectRef.path->toString() + "_" +
+                              externInfo.methodName + "_" +
+                              std::to_string(externInfo.originalCall.clone_id);
+         const auto hashCalc =
+             ToolsVariables::getSymbolicVariable(IR::getBitType(16), checksumLabel);
+         return hashCalc;
      }},
 
     // -----------------------------------------------------------------------------
@@ -277,18 +288,10 @@ const ExternMethodImpls EXTERN_METHOD_IMPLS({
     // TODO: Count currently has no effect in the symbolic interpreter.
     {"Counter.count",
      {"index"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
     {"Counter.count",
      {"index", "adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
     /// DirectCounter
     /// Increment the counter value.
     /// @param adjust_byte_count : optional parameter indicating value to be
@@ -296,18 +299,10 @@ const ExternMethodImpls EXTERN_METHOD_IMPLS({
     // TODO: Count currently has no effect in the symbolic interpreter.
     {"DirectCounter.count",
      {},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
     {"DirectCounter.count",
      {"adjust_byte_count"},
-     [](const ExternMethodImpls::ExternInfo &externInfo) {
-         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
-                           externInfo.externObjectRef.toString(), externInfo.methodName);
-         return nullptr;
-     }},
+     [](const ExternMethodImpls::ExternInfo &externInfo) { return nullptr; }},
 
     // -----------------------------------------------------------------------------
     /// Meter

--- a/targets/tofino/base/expression_resolver.cpp
+++ b/targets/tofino/base/expression_resolver.cpp
@@ -5,6 +5,7 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include "backends/p4tools/common/lib/variables.h"
 #include "backends/p4tools/modules/flay/core/externs.h"
 #include "backends/p4tools/modules/flay/targets/tofino/base/table_executor.h"
 #include "ir/irutils.h"
@@ -23,7 +24,638 @@ const IR::Expression *TofinoBaseExpressionResolver::processTable(const IR::P4Tab
 
 // Provides implementations of Tofino externs.
 namespace TofinoBaseExterns {
-const ExternMethodImpls EXTERN_METHOD_IMPLS({});
+
+const ExternMethodImpls EXTERN_METHOD_IMPLS({
+    // -----------------------------------------------------------------------------
+    // CHECKSUM
+    // -----------------------------------------------------------------------------
+    // Tofino checksum engine can verify the checksums for header-only checksums
+    // and calculate the residual (checksum minus the header field
+    // contribution) for checksums that include the payload.
+    // Checksum engine only supports 16-bit ones' complement checksums, also known
+    // as csum16 or internet checksum.
+    // -----------------------------------------------------------------------------
+    /// Add data to checksum.
+    /// @param data : List of fields to be added to checksum calculation. The
+    /// data must be byte aligned.
+    {"Checksum.add",
+     {"data"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Subtract data from existing checksum.
+    /// @param data : List of fields to be subtracted from the checksum. The
+    /// data must be byte aligned.
+    {"Checksum.subtract",
+     {"data"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Subtract data from existing checksum.
+    /// @param data : List of fields to be subtracted from the checksum. The
+    /// data must be byte aligned.
+    {"Checksum.verify",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Subtract all header fields after the current state and
+    /// return the calculated checksum value.
+    /// Marks the end position for residual checksum header.
+    /// All header fields extracted after will be automatically subtracted.
+    /// @param residual: The calculated checksum value for added fields.
+    {"Checksum.subtract_all_and_deposit",
+     {"residual"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Get the calculated checksum value.
+    /// @return : The calculated checksum value for added fields.
+    {"Checksum.get",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Calculate the checksum for a  given list of fields.
+    /// @param data : List of fields contributing to the checksum value.
+    /// @param zeros_as_ones : encode all-zeros value as all-ones.
+    {"Checksum.update",
+     {"data"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"Checksum.update",
+     {"data", "zeros_as_ones"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    // PARSER COUNTER
+    // -----------------------------------------------------------------------------
+    // Tofino parser counter can be used to extract header stacks or headers with
+    // variable length. Tofino has a single 8-bit signed counter that can be
+    // initialized with an immediate value or a header field.
+    // -----------------------------------------------------------------------------
+    /// Load the counter with an immediate value or a header field.
+    {"ParserCounter.set",
+     {"value"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Load the counter with a header field.
+    /// @param max : Maximum permitted value for counter (pre rotate/mask/add).
+    /// @param rotate : Right rotate (circular) the source field by this number of bits.
+    /// @param mask : Mask the rotated source field by 2 ^ (mask + 1) - 1.
+    /// @param add : Constant to add to the rotated and masked lookup field.
+    {"ParserCounter.set",
+     {"field", "max", "rotate", "mask", "add"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// @return true if counter value is zero.
+    {"ParserCounter.is_zero",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// @return true if counter value is negative.
+    {"ParserCounter.is_negative",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Add an immediate value to the parser counter.
+    /// @param value : Constant to add to the counter.
+    {"ParserCounter.increment",
+     {"value"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// Subtract an immediate value from the parser counter.
+    /// @param value : Constant to subtract from the counter.
+    {"ParserCounter.decrement",
+     {"value"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    // PARSER PRIORITY
+    // -----------------------------------------------------------------------------
+    // Tofino ingress parser compare the priority with a configurable!!! threshold
+    // to determine to whether drop the packet if the input buffer is congested.
+    // Egress parser does not perform any dropping.
+    // -----------------------------------------------------------------------------
+    /// Set a new priority for the packet.
+    /// param prio : parser priority for the parsed packet.
+    {"ParserPriority.set",
+     {"prio"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    // HASH ENGINE
+    // -----------------------------------------------------------------------------
+    // TODO: CRCPolynomial
+    // extern CRCPolynomial<T> {
+    //     CRCPolynomial(T coeff, bool reversed, bool msb, bool extended, T init, T xor);
+    // }
+    {"Hash.get",
+     {"data"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    /// Random number generator.
+    /// Return a random number with uniform distribution.
+    /// @return : random number between 0 and 2**W - 1
+    // -----------------------------------------------------------------------------
+    {"Random.get",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    // EXTERN FUNCTIONS
+    // -----------------------------------------------------------------------------
+    {"*method.max",
+     {"t1", "t2"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.min",
+     {"t1", "t2"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.funnel_shift_right",
+     {"dst", "src1", "src2", "shift_amount"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.invalidate",
+     {"field"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.is_validated",
+     {"field"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.port_metadata_unpack",
+     {"pkt"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.sizeInBits",
+     {"h"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"*method.sizeInBytes",
+     {"h"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Counter
+    /// Indexed counter with `size’ independent counter values.
+    // -----------------------------------------------------------------------------
+    // TODO: Count currently has no effect in the symbolic interpreter.
+    {"Counter.count",
+     {"index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"Counter.count",
+     {"index", "adjust_byte_count"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    /// DirectCounter
+    /// Increment the counter value.
+    /// @param adjust_byte_count : optional parameter indicating value to be
+    //                             subtracted from counter value.
+    // TODO: Count currently has no effect in the symbolic interpreter.
+    {"DirectCounter.count",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"DirectCounter.count",
+     {"adjust_byte_count"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Meter
+    // -----------------------------------------------------------------------------
+    {"Meter.execute",
+     {"index", "color"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"Meter.execute",
+     {"index", "color", "adjust_byte_count"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"Meter.execute",
+     {"index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"Meter.execute",
+     {"index", "adjust_byte_count"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Direct meter.
+    // -----------------------------------------------------------------------------
+    {"DirectMeter.execute",
+     {"color"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"DirectMeter.execute",
+     {"color", "adjust_byte_count"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"DirectMeter.execute",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"DirectMeter.execute",
+     {"adjust_byte_count"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// LPF
+    // -----------------------------------------------------------------------------
+    {"Lpf.execute",
+     {"val", "index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Direct LPF
+    // -----------------------------------------------------------------------------
+    {"DirectLpf.execute",
+     {"val"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// WRED
+    // -----------------------------------------------------------------------------
+    {"Wred.execute",
+     {"val", "index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Direct WRED
+    // -----------------------------------------------------------------------------
+    {"DirectWred.execute",
+     {"val"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Register
+    /// Return the value of register at specified index.
+    // -----------------------------------------------------------------------------
+    {"Register.read",
+     {"index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    /// Write value to register at specified index.
+    // -----------------------------------------------------------------------------
+    {"Register.write",
+     {"index", "value"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// DirectRegister
+    /// Return the value of the direct register.
+    // -----------------------------------------------------------------------------
+    {"DirectRegister.read",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    /// Write value to a direct register.
+    // -----------------------------------------------------------------------------
+    {"DirectRegister.read",
+     {"value"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// Return the value of the parameter.
+    // -----------------------------------------------------------------------------
+    {"RegisterParam.read",
+     {},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// MathUnit
+    // -----------------------------------------------------------------------------
+    {"MathUnit.execute",
+     {"x"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// RegisterAction
+    // This is implemented using an experimental feature in p4c and subject to
+    // change. See https://github.com/p4lang/p4-spec/issues/561 
+    // U execute(in I index) {
+    //     U rv;
+    //     T value = reg.read(index);
+    //     apply(value, rv);
+    //     reg.write(index, value);
+    //     return rv;
+    // }
+    // -----------------------------------------------------------------------------
+    {"RegisterAction.execute",
+     {"index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    // Apply the implemented abstract method using an index that increments each
+    // time. This method is useful for stateful logging.
+    // -----------------------------------------------------------------------------
+    {"RegisterAction.execute_log",
+     {""},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    // Abstract method that needs to be implemented when RegisterAction is
+    // instantiated.
+    // @param value : register value.
+    // @param rv : return value.
+    // -----------------------------------------------------------------------------
+    {"RegisterAction.apply",
+     {"value", "rv"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"RegisterAction.predicate",
+     {"cmplo", "cmphi"}, // TODO: the two arguments are both optional
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    
+    // -----------------------------------------------------------------------------
+    // DirectRegisterAction
+    //
+    // U execute() {
+    //     U rv;
+    //     T value = reg.read();
+    //     apply(value, rv);
+    //     reg.write(value);
+    //     return rv;
+    // }
+    // -----------------------------------------------------------------------------
+    {"DirectRegisterAction.execute",
+     {"index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    // DirectRegisterAction.apply
+    // -----------------------------------------------------------------------------
+    {"DirectRegisterAction.apply",
+     {"value", "rv"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    // DirectRegisterAction.predicate
+    // -----------------------------------------------------------------------------
+    {"DirectRegisterAction.predicate",
+     {"cmplo", "cmphi"}, // TODO: the two arguments are both optional
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    /// SelectorAction
+    // -----------------------------------------------------------------------------
+    {"SelectorAction.execute",
+     {"index"},
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    {"SelectorAction.apply",
+     {"value", "rv"}, // TODO: argument `rv` is both optional
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    
+    // -----------------------------------------------------------------------------
+    // Tofino supports mirroring both at the ingress and egress. Ingress deparser
+    // creates a copy of the original ingress packet and prepends the mirror header.
+    // Egress deparser first constructs the output packet and then prepends the
+    // mirror header.
+    // -----------------------------------------------------------------------------
+    /// Mirror the packet.
+    // -----------------------------------------------------------------------------
+    {"Mirror.emit",
+     {"session_id"}, 
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    /// Write @hdr into the ingress/egress mirror buffer.
+    /// @param hdr : T can be a header type.
+    // -----------------------------------------------------------------------------
+    {"Mirror.emit",
+     {"session_id", "hdr"}, 
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    
+    // -----------------------------------------------------------------------------
+    // Tofino supports packet resubmission at the end of ingress pipeline. When
+    // a packet is resubmitted, the original packet reference and some limited
+    // amount of metadata (64 bits) are passed back to the packet’s original
+    // ingress buffer, where the packet is enqueued again.
+    // -----------------------------------------------------------------------------
+    /// Resubmit the packet.
+    // -----------------------------------------------------------------------------
+    {"Resubmit.emit",
+     {}, 
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+    // -----------------------------------------------------------------------------
+    /// Resubmit the packet and prepend it with @hdr.
+    /// @param hdr : T can be a header type.
+    // -----------------------------------------------------------------------------
+    {"Resubmit.emit",
+     {"hdr"}, 
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }},
+
+    // -----------------------------------------------------------------------------
+    // Digest
+    // -----------------------------------------------------------------------------
+    {"Digest.pack",
+     {"data"}, 
+     [](const ExternMethodImpls::ExternInfo &externInfo) {
+         P4C_UNIMPLEMENTED("Unimplemented extern method: %1%.%2%",
+                           externInfo.externObjectRef.toString(), externInfo.methodName);
+         return nullptr;
+     }}
+});
 }  // namespace TofinoBaseExterns
 
 const IR::Expression *TofinoBaseExpressionResolver::processExtern(

--- a/targets/tofino/test/Tofino1Xfail.cmake
+++ b/targets/tofino/test/Tofino1Xfail.cmake
@@ -16,17 +16,13 @@ p4tools_add_xfail_reason(
   tna_meter_lpf_wred.p4  # meter_0/meter.execute;: unknown type
   tna_operations.p4  # direct_counter_0/direct_counter.count;: unknown type
   tna_mirror.p4  # Unknown or unimplemented extern method: mirror.emit
-  tna_multicast.p4  # Unknown or unimplemented extern method: ipv4_checksum.update
   tna_port_metadata_extern.p4  # Unable to find var pkt; in the symbolic environment.
   tna_pvs.p4  # Unable to find var vs_0/vs; in the symbolic environment.
   tna_random.p4  # Unknown or unimplemented extern method: rnd1.get
   tna_register.p4  # Unknown or unimplemented extern method: test_reg_action.execute
   tna_resubmit.p4  # Unable to find var pkt; in the symbolic environment.
-  tna_snapshot.p4  # Unknown or unimplemented extern method: ipv4_checksum.update
   tna_symmetric_hash.p4  # Unknown or unimplemented extern method: my_symmetric_hash.ge
-  tna_simple_switch.p4  # srv6_cnt1/cnt1.count;: unknown type
   tna_32q_2pipe.p4  # meter_0/meter.execute;: unknown type
-  tna_action_profile.p4  # error: Unknown or unimplemented extern method: ipv4_checksum.update
   tna_action_selector.p4  # Compiler Bug: No parameter named size
 )
 
@@ -40,14 +36,17 @@ p4tools_add_xfail_reason(
   "flay-tofino1-tna"
   "Unable to find node .* in the reachability map of this execution state"
   bri_with_pdfixed_thrift.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
+  tna_action_profile.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_bridged_md.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_field_slice.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_lpm_match.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
+  tna_multicast.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_pktgen.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_port_metadata.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_ports.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_proxy_hash.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_range_match.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
+  tna_snapshot.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_timestamp.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
   tna_idletimeout.p4  # error: Unable to find node set_bypass_egress in the reachability map of this execution state.
 )

--- a/targets/tofino/test/Tofino1Xfail.cmake
+++ b/targets/tofino/test/Tofino1Xfail.cmake
@@ -5,22 +5,21 @@
 p4tools_add_xfail_reason(
   "flay-tofino1-tna"
   "Compiler Bug|Unimplemented compiler support"
-  tna_counter.p4  # direct_counter_0/direct_counter.count;: unknown type
-  tna_checksum.p4  # Unknown or unimplemented extern method: ipv4_checksum.add
-  tna_custom_hash.p4  # Unknown or unimplemented extern method: hash1.get
-  tna_dkm.p4  # cntr_0/cntr.count;: unknown type
-  tna_digest.p4  # Unknown or unimplemented extern method: digest_a.pack
-  tna_dyn_hashing.p4  # Unknown or unimplemented extern method: hash_1.get
-  tna_exact_match.p4  # cntr_0/cntr.count;: unknown type
-  tna_meter_bytecount_adjust.p4  # meter_0/meter.execute;: unknown type
-  tna_meter_lpf_wred.p4  # meter_0/meter.execute;: unknown type
-  tna_operations.p4  # direct_counter_0/direct_counter.count;: unknown type
-  tna_mirror.p4  # Unknown or unimplemented extern method: mirror.emit
+  tna_counter.p4  # No parameter named n_counters
+  tna_custom_hash.p4  # Unimplemented extern method: hash1.get
+  tna_dkm.p4  # Unimplemented extern method: meter.execute
+  tna_digest.p4  # Unimplemented extern method: digest_a.pack
+  tna_dyn_hashing.p4  # Unimplemented extern method: hash_1.get
+  tna_exact_match.p4  # Unimplemented extern method: meter.execute
+  tna_meter_bytecount_adjust.p4  # No parameter named n_meters
+  tna_meter_lpf_wred.p4  # No parameter named n_meters
+  tna_operations.p4  # No parameter named n_counters
+  tna_mirror.p4  # Unimplemented extern method: mirror.emit
   tna_port_metadata_extern.p4  # Unable to find var pkt; in the symbolic environment.
   tna_pvs.p4  # Unable to find var vs_0/vs; in the symbolic environment.
   tna_random.p4  # Unknown or unimplemented extern method: rnd1.get
   tna_register.p4  # Unknown or unimplemented extern method: test_reg_action.execute
-  tna_resubmit.p4  # Unable to find var pkt; in the symbolic environment.
+  tna_resubmit.p4  # No parameter named n_counters
   tna_symmetric_hash.p4  # Unknown or unimplemented extern method: my_symmetric_hash.ge
   tna_32q_2pipe.p4  # meter_0/meter.execute;: unknown type
   tna_action_selector.p4  # Compiler Bug: No parameter named size


### PR DESCRIPTION
Externs used by `tna_simple_switch` include `DirectCounter` and `Checksum`.
I return `nullptr` for `DirectCounter`, and return symbol value for `Checksum`'s `verify` and `update` but do nothing for `add` (since I currently don't maintain the value for the Checksum object).