### PR TITLE
Add failing tests to Xfails.

### DIFF
--- a/targets/bmv2/test/BMv2V1ModelXfail.cmake
+++ b/targets/bmv2/test/BMv2V1ModelXfail.cmake
@@ -86,6 +86,7 @@ p4tools_add_xfail_reason(
   issue2345-multiple_dependencies.p4
   issue2345-with_nested_if.p4
   issue420.p4
+  predication_issue_3.p4
 )
 
 # We are trying to map a duplicate condition to the reachability map.


### PR DESCRIPTION
Turns out this failure is something we can do little about. The transformation is 
```p4
val = 3w0;
bound = 3w1;
if (val < bound) {
    tmp_1 = val;
} else {
    tmp_1 = bound;
}
```
which is constantfolded after propagation. So the condition never shows up. 