### PR TITLE
control-plane for tna

### DIFF
--- a/targets/tofino/control_plane_architecture.cpp
+++ b/targets/tofino/control_plane_architecture.cpp
@@ -4,7 +4,7 @@ namespace P4::ControlPlaneAPI::Standard {
 
 P4RuntimeArchHandlerTofino::P4RuntimeArchHandlerTofino(ReferenceMap *refMap, TypeMap *typeMap,
                                                        const IR::ToplevelBlock *evaluatedProgram)
-    : P4RuntimeArchHandlerCommon<Arch::PSA>(refMap, typeMap, evaluatedProgram) {}
+    : P4RuntimeArchHandlerCommon<Arch::TNA>(refMap, typeMap, evaluatedProgram) {}
 
 P4RuntimeArchHandlerIface *TofinoArchHandlerBuilder::operator()(
     ReferenceMap *refMap, TypeMap *typeMap, const IR::ToplevelBlock *evaluatedProgram) const {

--- a/targets/tofino/control_plane_architecture.h
+++ b/targets/tofino/control_plane_architecture.h
@@ -2,12 +2,84 @@
 #define BACKENDS_P4TOOLS_MODULES_FLAY_TARGETS_TOFINO_CONTROL_PLANE_ARCHITECTURE_H_
 #include "control-plane/p4RuntimeArchStandard.h"
 
-namespace P4::ControlPlaneAPI::Standard {
+namespace P4::ControlPlaneAPI::Helpers {
+/// @ref CounterlikeTraits<> specialization for @ref CounterExtern for TNA
+template <>
+struct CounterlikeTraits<Standard::CounterExtern<Standard::Arch::TNA>> {
+    static const cstring name() { return "counter"; }
+    static const cstring directPropertyName() { return "tna_direct_counter"; }
+    static const cstring typeName() { return "Counter"; }
+    static const cstring directTypeName() { return "DirectCounter"; }
+    static const cstring sizeParamName() { return "size"; }
+    static p4configv1::CounterSpec::Unit mapUnitName(const cstring name) {
+        using p4configv1::CounterSpec;
+        if (name == "PACKETS")
+            return CounterSpec::PACKETS;
+        else if (name == "BYTES")
+            return CounterSpec::BYTES;
+        else if (name == "PACKETS_AND_BYTES")
+            return CounterSpec::BOTH;
+        return CounterSpec::UNSPECIFIED;
+    }
+    // the index of the type parameter for the counter index, in the type
+    // parameter list of the extern type declaration.
+    static std::optional<size_t> indexTypeParamIdx() { return 1; }
+};
 
+/// @ref CounterlikeTraits<> specialization for @ref MeterExtern for TNA
+template <>
+struct CounterlikeTraits<Standard::MeterExtern<Standard::Arch::TNA>> {
+    static const cstring name() { return "meter"; }
+    static const cstring directPropertyName() { return "tna_direct_meter"; }
+    static const cstring typeName() { return "Meter"; }
+    static const cstring directTypeName() { return "DirectMeter"; }
+    static const cstring sizeParamName() { return "size"; }
+    static p4configv1::MeterSpec::Unit mapUnitName(const cstring name) {
+        using p4configv1::MeterSpec;
+        if (name == "PACKETS")
+            return MeterSpec::PACKETS;
+        else if (name == "BYTES")
+            return MeterSpec::BYTES;
+        return MeterSpec::UNSPECIFIED;
+    }
+    // the index of the type parameter for the meter index, in the type
+    // parameter list of the extern type declaration.
+    static std::optional<size_t> indexTypeParamIdx() { return 0; }
+};
+}  // namespace P4::ControlPlaneAPI::Helpers
+
+namespace P4::ControlPlaneAPI::Standard {
+template <>
+struct ActionProfileTraits<Arch::TNA> {
+    static const cstring name() { return "action profile"; }
+    static const cstring propertyName() { return "tna_implementation"; }
+    static const cstring typeName() { return "ActionProfile"; }
+    static const cstring sizeParamName() { return "size"; }
+};
+
+template <>
+struct ActionSelectorTraits<Arch::TNA> : public ActionProfileTraits<Arch::TNA> {
+    static const cstring name() { return "action selector"; }
+    static const cstring typeName() { return "ActionSelector"; }
+};
+
+template <>
+struct RegisterTraits<Arch::TNA> {
+    static const cstring name() { return "register"; }
+    static const cstring typeName() { return "Register"; }
+    static const cstring sizeParamName() { return "size"; }
+    static size_t dataTypeParamIdx() { return 0; }
+    // the index of the type parameter for the register index, in the type
+    // parameter list of the extern type declaration.
+    static std::optional<size_t> indexTypeParamIdx() { return 1; }
+};
+}  // namespace P4::ControlPlaneAPI::Standard
+
+namespace P4::ControlPlaneAPI::Standard {
 /// Implements @ref P4RuntimeArchHandlerIface for the Tofino architecture. The
 /// overridden methods will be called by the @P4RuntimeSerializer to collect and
 /// serialize tofino-specific symbols which are exposed to the control-plane.
-class P4RuntimeArchHandlerTofino final : public P4RuntimeArchHandlerCommon<Arch::PSA> {
+class P4RuntimeArchHandlerTofino final : public P4RuntimeArchHandlerCommon<Arch::TNA> {
  public:
     P4RuntimeArchHandlerTofino(ReferenceMap *refMap, TypeMap *typeMap,
                                const IR::ToplevelBlock *evaluatedProgram);

--- a/targets/tofino/test/Tofino1Xfail.cmake
+++ b/targets/tofino/test/Tofino1Xfail.cmake
@@ -5,15 +5,12 @@
 p4tools_add_xfail_reason(
   "flay-tofino1-tna"
   "Compiler Bug|Unimplemented compiler support"
-  tna_counter.p4  # No parameter named n_counters
-  tna_meter_bytecount_adjust.p4  # No parameter named n_meters
-  tna_meter_lpf_wred.p4  # No parameter named n_meters
-  tna_operations.p4  # No parameter named n_counters
+  tna_meter_lpf_wred.p4  # Unimplemented extern method: simple_lpf.execute
   tna_mirror.p4  # Unimplemented extern method: mirror.emit
   tna_port_metadata_extern.p4  # Unable to find var pkt; in the symbolic environment.
   tna_pvs.p4  # Unable to find var vs_0/vs; in the symbolic environment.
-  tna_resubmit.p4  # No parameter named n_counters
-  tna_32q_2pipe.p4  # No parameter named n_meters
+  tna_resubmit.p4  # Unable to find var pkt; in the symbolic environment.
+  tna_32q_2pipe.p4  # The Tofno1 architecture requires 6 pipes. Received 12.
   tna_action_selector.p4  # Compiler Bug: No parameter named size
 )
 


### PR DESCRIPTION
To fix issues of unmatched constructor parameter names (`n_counters` vs `size`...), we reuse `P4RuntimeArchHandlerCommon` for TNA for now. 

This must be compiled with the version of p4c that contains TNA in Arch enum. fruffy/p4c#4