### PR TITLE
Skip if statements within Declaration_Instance. We do not have full register support yet.

### DIFF
--- a/passes/elim_dead_code.cpp
+++ b/passes/elim_dead_code.cpp
@@ -17,12 +17,13 @@ ElimDeadCode::ElimDeadCode(const P4::ReferenceMap &refMap,
     : reachabilityMap(reachabilityMap), refMap(refMap) {}
 
 std::optional<bool> ElimDeadCode::getAnyReachability(
-    std::vector<const ReachabilityExpression *> condVector) {
+    const std::vector<const ReachabilityExpression *> &condVector) {
     for (const auto *condition : condVector) {
         auto reachability = condition->getReachability();
         if (!reachability) {
             return std::nullopt;
-        } else if (reachability.value()) {
+        }
+        if (reachability.value()) {
             return true;
         }
     }
@@ -32,6 +33,11 @@ std::optional<bool> ElimDeadCode::getAnyReachability(
 const IR::Node *ElimDeadCode::preorder(IR::IfStatement *stmt) {
     // Only analyze statements with valid source location.
     if (!stmt->srcInfo.isValid()) {
+        return stmt;
+    }
+
+    // Skip if statements within declaration instances for now. These may be registers for example.
+    if (findContext<IR::Declaration_Instance>() != nullptr) {
         return stmt;
     }
 

--- a/passes/elim_dead_code.h
+++ b/passes/elim_dead_code.h
@@ -42,7 +42,8 @@ class ElimDeadCode : public Transform {
 
     /// @return true if any of the condition is reachable; false if none of the conditions are
     /// reachable; std::nullopt if the reachability is ambiguous.
-    std::optional<bool> getAnyReachability(std::vector<const ReachabilityExpression *> condVector);
+    std::optional<bool> getAnyReachability(
+        const std::vector<const ReachabilityExpression *> &condVector);
 
     [[nodiscard]] std::vector<EliminatedReplacedPair> getEliminatedNodes() const;
 };


### PR DESCRIPTION
This makes it possible to apply Flay to the Tofino switch programs (in limited fashion).