### PR TITLE
Implement a pass to collapse data plane variables.

### DIFF
--- a/.github/workflows/ci-test-m1.yml
+++ b/.github/workflows/ci-test-m1.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-14
     env:
       CTEST_PARALLEL_LEVEL: 4
+      CMAKE_UNITY_BUILD: ON
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set(FLAY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/control_plane/control_plane_objects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/control_plane/id_to_ir_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/control_plane/symbolic_state.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/simplify_expression.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/collapse_dataplane_variables.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/compiler_target.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/execution_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/expression_resolver.cpp
@@ -72,6 +72,7 @@ set(FLAY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/core/parser_stepper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/program_info.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/reachability.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/simplify_expression.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/stepper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/substitute_placeholders.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/symbolic_executor.cpp

--- a/core/collapse_dataplane_variables.cpp
+++ b/core/collapse_dataplane_variables.cpp
@@ -1,0 +1,222 @@
+#include "backends/p4tools/modules/flay/core/collapse_dataplane_variables.h"
+
+namespace P4Tools::Flay {
+
+namespace {
+
+/// Generates a random string.
+/// TODO: It would be nice if this was using a UUID generator.
+std::string generateRandomString() {
+    constexpr int kLength = 20;
+    static const char alphaNumericCharacters[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    std::string randomString;
+    randomString.reserve(kLength);
+
+    for (int i = 0; i < kLength; ++i) {
+        randomString += alphaNumericCharacters[rand() % (sizeof(alphaNumericCharacters) - 1)];
+    }
+
+    return randomString;
+}
+
+const IR::DataPlaneVariable *getRandomDataPlaneVariable(const IR::Type *type) {
+    return new IR::DataPlaneVariable(type, generateRandomString());
+}
+
+/// Computes which bits of an expression are sourced from a data-plane variable.
+/// These bits are tainted.
+static bitvec computeDataPlaneBits(const IR::Expression *expr) {
+    CHECK_NULL(expr);
+    if (expr->is<IR::SymbolicVariable>()) {
+        return {};
+    }
+
+    if (expr->is<IR::DataPlaneVariable>()) {
+        return {0, static_cast<size_t>(expr->type->width_bits())};
+    }
+
+    if (const auto *concatExpr = expr->to<IR::Concat>()) {
+        auto lDataPlaneVariableBits = computeDataPlaneBits(concatExpr->left);
+        auto rDataPlaneVariableBits = computeDataPlaneBits(concatExpr->right);
+        return (lDataPlaneVariableBits << concatExpr->right->type->width_bits()) |
+               rDataPlaneVariableBits;
+    }
+    if (const auto *slice = expr->to<IR::Slice>()) {
+        auto subDataPlaneVariableBits = computeDataPlaneBits(slice->e0);
+        return subDataPlaneVariableBits.getslice(slice->getL(), slice->type->width_bits());
+    }
+    if (const auto *binaryExpr = expr->to<IR::Operation_Binary>()) {
+        bitvec fullmask(0, expr->type->width_bits());
+        if (const auto *shl = binaryExpr->to<IR::Shl>()) {
+            if (const auto *shiftConst = shl->right->to<IR::Constant>()) {
+                int shift = static_cast<int>(shiftConst->value);
+                return fullmask & (computeDataPlaneBits(shl->left) << shift);
+            }
+            return fullmask;
+        }
+        if (const auto *shr = binaryExpr->to<IR::Shr>()) {
+            if (const auto *shiftConst = shr->right->to<IR::Constant>()) {
+                int shift = static_cast<int>(shiftConst->value);
+                return computeDataPlaneBits(shr->left) >> shift;
+            }
+            return fullmask;
+        }
+        if (binaryExpr->is<IR::BAnd>() || binaryExpr->is<IR::BOr>() || binaryExpr->is<IR::BXor>()) {
+            // Bitwise binary operations cannot taint other bits than those tainted in either lhs or
+            // rhs.
+            return computeDataPlaneBits(binaryExpr->left) | computeDataPlaneBits(binaryExpr->right);
+        }
+        // Be conservative here. If either of the expressions contain even a single tainted bit, the
+        // entire operation is tainted. The reason is that we need to account for overflow. A
+        // tainted MSB or LSB can cause an expression to overflow and underflow.
+        auto lDataPlaneVariableBits = computeDataPlaneBits(binaryExpr->left);
+        auto rDataPlaneVariableBits = computeDataPlaneBits(binaryExpr->right);
+        if (lDataPlaneVariableBits.empty() && rDataPlaneVariableBits.empty()) {
+            return {};
+        }
+        return fullmask;
+    }
+    if (const auto *unaryExpr = expr->to<IR::Operation_Unary>()) {
+        return computeDataPlaneBits(unaryExpr->expr);
+    }
+    if (expr->is<IR::Literal>()) {
+        return {};
+    }
+    if (expr->is<IR::DefaultExpression>()) {
+        return {};
+    }
+    if (const auto *mux = expr->to<IR::Mux>()) {
+        return computeDataPlaneBits(mux->e1) & computeDataPlaneBits(mux->e2);
+    }
+    BUG("Data-plane variable pair collection is unsupported for %1% of type %2%", expr,
+        expr->node_type_name());
+}
+
+/// Returns true if the expression could be folded into a single data-plane variable.
+bool hasDataPlaneVariable(const IR::Expression *expr) {
+    if (expr->is<IR::DataPlaneVariable>()) {
+        return true;
+    }
+    if (expr->is<IR::SymbolicVariable>()) {
+        return false;
+    }
+
+    if (const auto *structExpr = expr->to<IR::StructExpression>()) {
+        return std::any_of(structExpr->components.begin(), structExpr->components.end(),
+                           [](const IR::NamedExpression *subExpr) {
+                               return hasDataPlaneVariable(subExpr->expression);
+                           });
+    }
+    if (const auto *listExpr = expr->to<IR::ListExpression>()) {
+        return std::any_of(
+            listExpr->components.begin(), listExpr->components.end(),
+            [](const IR::Expression *subExpr) { return hasDataPlaneVariable(subExpr); });
+    }
+    if (const auto *binaryExpr = expr->to<IR::Operation_Binary>()) {
+        // We can short-circuit '&&'...
+        if (const auto *lAndExpr = binaryExpr->to<IR::LAnd>()) {
+            if (const auto *boolVal = lAndExpr->left->to<IR::BoolLiteral>()) {
+                if (!boolVal->value) {
+                    return false;
+                }
+            }
+        }
+        // ...and '||' in some cases.
+        if (const auto *lOrExpr = binaryExpr->to<IR::LOr>()) {
+            if (const auto *boolVal = lOrExpr->left->to<IR::BoolLiteral>()) {
+                if (boolVal->value) {
+                    return false;
+                }
+            }
+        }
+        return hasDataPlaneVariable(binaryExpr->left) || hasDataPlaneVariable(binaryExpr->right);
+    }
+    if (const auto *unaryExpr = expr->to<IR::Operation_Unary>()) {
+        return hasDataPlaneVariable(unaryExpr->expr);
+    }
+    if (expr->is<IR::Literal>()) {
+        return false;
+    }
+    if (const auto *slice = expr->to<IR::Slice>()) {
+        auto slLeftInt = slice->e1->checkedTo<IR::Constant>()->asInt();
+        auto slRightInt = slice->e2->checkedTo<IR::Constant>()->asInt();
+        auto dataPlaneBits = computeDataPlaneBits(slice->e0);
+        return !(dataPlaneBits & bitvec(slRightInt, slLeftInt - slRightInt + 1)).empty();
+    }
+    if (const auto *mux = expr->to<IR::Mux>()) {
+        return hasDataPlaneVariable(mux->e1) && hasDataPlaneVariable(mux->e2);
+    }
+    if (expr->is<IR::DefaultExpression>()) {
+        return false;
+    }
+    BUG("Data-plane variable checking is unsupported for %1% of type %2%", expr,
+        expr->node_type_name());
+}
+
+}  // namespace
+
+DataPlaneVariablePropagator::DataPlaneVariablePropagator() { visitDagOnce = false; }
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::Operation_Unary *unary_op) {
+    if (hasDataPlaneVariable(unary_op->expr)) {
+        return unary_op->expr;
+    }
+    return unary_op;
+}
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::Cast *cast) { return cast; }
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::Operation_Binary *bin_op) {
+    if (hasDataPlaneVariable(bin_op->left)) {
+        return bin_op->left;
+    }
+    if (hasDataPlaneVariable(bin_op->right)) {
+        return bin_op->right;
+    }
+    return bin_op;
+}
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::LAnd *lAnd) {
+    if (lAnd->left->is<IR::DataPlaneVariable>() && lAnd->right->is<IR::DataPlaneVariable>()) {
+        return new IR::SymbolicVariable(IR::Type_Boolean::get(), generateRandomString());
+    }
+    return lAnd;
+}
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::Operation_Relation *relOp) {
+    if (hasDataPlaneVariable(relOp->left) || hasDataPlaneVariable(relOp->right)) {
+        return new IR::SymbolicVariable(IR::Type_Boolean::get(), generateRandomString());
+    }
+    return relOp;
+}
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::Concat *concat) { return concat; }
+
+const IR::Node *DataPlaneVariablePropagator::postorder(IR::Slice *slice) {
+    if (hasDataPlaneVariable(slice)) {
+        // We assume a bit type here...
+        BUG_CHECK(!slice->e0->is<IR::Type_Bits>(),
+                  "Expected Type_Bits for the slice expression but received %1%",
+                  slice->e0->type->node_type_name());
+        auto slLeftInt = slice->e1->checkedTo<IR::Constant>()->asInt();
+        auto slRightInt = slice->e2->checkedTo<IR::Constant>()->asInt();
+        auto width = 1 + slLeftInt - slRightInt;
+        return getRandomDataPlaneVariable(IR::getBitType(width));
+    }
+    return slice;
+}
+
+const IR::Node *DataPlaneVariablePropagator::preorder(IR::Mux *mux) {
+    // TODO: We should not need to use this prune but it is needed to avoid a
+    // massive slowdown for reasons unclear to me.
+    prune();
+    if (hasDataPlaneVariable(mux->e1) && hasDataPlaneVariable(mux->e2)) {
+        return getRandomDataPlaneVariable(mux->type);
+    }
+    return mux;
+}
+
+}  // namespace P4Tools::Flay

--- a/core/collapse_dataplane_variables.h
+++ b/core/collapse_dataplane_variables.h
@@ -1,0 +1,27 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_FLAY_CORE_COLLAPSE_DATAPLANE_VARIABLES_H_
+#define BACKENDS_P4TOOLS_MODULES_FLAY_CORE_COLLAPSE_DATAPLANE_VARIABLES_H_
+
+#include "ir/ir.h"
+#include "ir/irutils.h"
+#include "ir/node.h"
+#include "ir/visitor.h"
+
+namespace P4Tools::Flay {
+
+class DataPlaneVariablePropagator : public Transform {
+    const IR::Node *postorder(IR::Operation_Unary *unary_op) override;
+    const IR::Node *postorder(IR::Cast *cast) override;
+    const IR::Node *postorder(IR::Operation_Binary *bin_op) override;
+    const IR::Node *postorder(IR::LAnd *lAnd) override;
+    const IR::Node *postorder(IR::Operation_Relation *relOp) override;
+    const IR::Node *postorder(IR::Concat *concat) override;
+    const IR::Node *postorder(IR::Slice *slice) override;
+    const IR::Node *preorder(IR::Mux *mux) override;
+
+ public:
+    DataPlaneVariablePropagator();
+};
+
+}  // namespace P4Tools::Flay
+
+#endif /* BACKENDS_P4TOOLS_MODULES_FLAY_CORE_COLLAPSE_DATAPLANE_VARIABLES_H_ */

--- a/core/execution_state.cpp
+++ b/core/execution_state.cpp
@@ -38,8 +38,7 @@ const IR::Expression *ExecutionState::createSymbolicExpression(const IR::Type *i
         }
         if (structType->is<IR::Type_Header>()) {
             cstring labelId = label + "_" + ToolsVariables::VALID;
-            const auto *validity =
-                ToolsVariables::getSymbolicVariable(IR::Type_Boolean::get(), labelId);
+            const auto *validity = new IR::DataPlaneVariable(IR::Type_Boolean::get(), labelId);
             // TODO: We keep the struct type anonymous because we do not know it.
             return new IR::HeaderExpression(structType, nullptr, fields, validity);
         }
@@ -55,7 +54,7 @@ const IR::Expression *ExecutionState::createSymbolicExpression(const IR::Type *i
         return new IR::HeaderStackExpression(fields, inputType);
     }
     if (resolvedType->is<IR::Type_Base>()) {
-        return ToolsVariables::getSymbolicVariable(resolvedType, label);
+        return new IR::DataPlaneVariable(resolvedType, label);
     }
     P4C_UNIMPLEMENTED("Requesting a symbolic expression for %1% of type %2%", inputType,
                       inputType->node_type_name());

--- a/core/expression_resolver.cpp
+++ b/core/expression_resolver.cpp
@@ -402,18 +402,17 @@ static const ExternMethodImpls EXTERN_METHOD_IMPLS(
           // This argument is the structure being written by the extract.
           const auto &extractRef = args->at(0)->expression->checkedTo<IR::InOutReference>()->ref;
           extractRef->type->checkedTo<IR::Type_Header>();
-          const auto &headerRefValidity = ToolsVariables::getHeaderValidity(extractRef);
           // First, set the validity.
           auto extractLabel =
               externObjectRef.path->toString() + "_" + methodName + "_" + extractRef->toString();
-          state.set(headerRefValidity,
-                    ToolsVariables::getSymbolicVariable(IR::Type_Boolean::get(), extractLabel));
+          state.set(ToolsVariables::getHeaderValidity(extractRef),
+                    new IR::DataPlaneVariable(IR::Type_Boolean::get(), extractLabel));
           // Then, set the fields.
           const auto flatFields = state.getFlatFields(extractRef);
           for (const auto &field : flatFields) {
               auto extractFieldLabel = externObjectRef.path->toString() + "_" + methodName + "_" +
                                        extractRef->toString() + "_" + field.toString();
-              state.set(field, ToolsVariables::getSymbolicVariable(field->type, extractFieldLabel));
+              state.set(field, new IR::DataPlaneVariable(field->type, extractFieldLabel));
           }
           return nullptr;
       }},
@@ -428,12 +427,11 @@ static const ExternMethodImpls EXTERN_METHOD_IMPLS(
           // This argument is the structure being written by the extract.
           const auto &extractRef = args->at(0)->expression->checkedTo<IR::InOutReference>()->ref;
           extractRef->type->checkedTo<IR::Type_Header>();
-          const auto &headerRefValidity = ToolsVariables::getHeaderValidity(extractRef);
           // First, set the validity.
           auto extractLabel =
               externObjectRef.path->toString() + "_" + methodName + "_" + extractRef->toString();
-          state.set(headerRefValidity,
-                    ToolsVariables::getSymbolicVariable(IR::Type_Boolean::get(), extractLabel));
+          state.set(ToolsVariables::getHeaderValidity(extractRef),
+                    new IR::DataPlaneVariable(IR::Type_Boolean::get(), extractLabel));
           // Then, set the fields.
           const auto flatFields = state.getFlatFields(extractRef);
           for (const auto &field : flatFields) {
@@ -447,11 +445,10 @@ static const ExternMethodImpls EXTERN_METHOD_IMPLS(
                   assignedType->assignedSize = assignedType->size;
                   auto *typedField = field.clone();
                   typedField->type = assignedType;
-                  state.set(*typedField, ToolsVariables::getSymbolicVariable(typedField->type,
-                                                                             extractFieldLabel));
+                  state.set(*typedField,
+                            new IR::DataPlaneVariable(typedField->type, extractFieldLabel));
               } else {
-                  state.set(field,
-                            ToolsVariables::getSymbolicVariable(field->type, extractFieldLabel));
+                  state.set(field, new IR::DataPlaneVariable(field->type, extractFieldLabel));
               }
           }
           return nullptr;

--- a/core/simplify_expression.cpp
+++ b/core/simplify_expression.cpp
@@ -3,6 +3,8 @@
 #include <optional>
 #include <utility>
 
+#include "backends/p4tools/modules/flay/core/collapse_dataplane_variables.h"
+#include "backends/p4tools/modules/flay/options.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/p4/strengthReduction.h"
 #include "ir/irutils.h"
@@ -177,6 +179,11 @@ const IR::Expression *simplify(const IR::Expression *expr) {
         new FoldMuxConditionDown(),
         new LiftMuxConditions(),
     });
+    if (FlayOptions::get().collapseDataPlaneOperations()) {
+        pass.addPasses({
+            new Flay::DataPlaneVariablePropagator(),
+        });
+    }
     expr = expr->apply(pass);
     BUG_CHECK(::errorCount() == 0, "Encountered errors while trying to simplify expressions.");
     return expr;

--- a/core/symbolic_executor.cpp
+++ b/core/symbolic_executor.cpp
@@ -19,8 +19,6 @@ void SymbolicExecutor::run() {
     stepper.initializeState();
     for (const auto *node : *pipelineSequence) {
         node->apply(stepper);
-        // executionState.printSymbolicEnv();
-        // exit(1);
     }
     /// Substitute any placeholder variables encountered in the execution state.
     printInfo("Substituting placeholder variables...");

--- a/flay.def
+++ b/flay.def
@@ -24,3 +24,16 @@ class Placeholder : Expression {
 
     dbprint { out << "@" + label +"(" << type << ")@"; }
 }
+
+
+/// Signifies that a particular expression is a variable coming from the data plane.
+class DataPlaneVariable : SymbolicVariable {
+#noconstructor
+
+    /// A data-plane variable always has a type and no source info.
+    DataPlaneVariable(Type type, cstring label) : SymbolicVariable(type, label) {}
+
+    toString { return "@" + label +"(" + type->toString() + ")@"; }
+
+    dbprint { out << "@" + label +"(" << type << ")@"; }
+}

--- a/options.cpp
+++ b/options.cpp
@@ -89,6 +89,16 @@ FlayOptions::FlayOptions(const std::string &message) : AbstractP4cToolOptions(me
             return true;
         },
         "The path to the output file of the optimized P4 program.");
+    registerOption(
+        "--preserve-data-plane-variables", nullptr,
+        [this](const char *) {
+            collapseDataPlaneOperations_ = false;
+            return true;
+        },
+        "Preserve arithmetic operations on variables sourced from the data plane (e.g., header "
+        "reads). Flay "
+        "will otherwise collapse these operations only perform live-variable analysis on "
+        "control-plane sourced variables.");
 }
 
 std::filesystem::path FlayOptions::getControlPlaneConfig() const {
@@ -114,5 +124,7 @@ bool FlayOptions::isStrict() const { return strict_; }
 std::optional<std::filesystem::path> FlayOptions::getOptimizedOutputFile() const {
     return optimizedOutputFile_;
 }
+
+bool FlayOptions::collapseDataPlaneOperations() const { return collapseDataPlaneOperations_; }
 
 }  // namespace P4Tools

--- a/options.h
+++ b/options.h
@@ -49,6 +49,8 @@ class FlayOptions : public AbstractP4cToolOptions {
 
     [[nodiscard]] std::optional<std::filesystem::path> getOptimizedOutputFile() const;
 
+    [[nodiscard]] bool collapseDataPlaneOperations() const;
+
  protected:
     explicit FlayOptions(
         const std::string &message = "Remove control-plane dead code from a P4 program.");
@@ -78,6 +80,9 @@ class FlayOptions : public AbstractP4cToolOptions {
 
     /// The path to the output file of the optimized P4 program.
     std::optional<std::filesystem::path> optimizedOutputFile_ = std::nullopt;
+
+    /// Collapse arithmetic operations on data plane variables.
+    bool collapseDataPlaneOperations_ = true;
 };
 
 }  // namespace P4Tools


### PR DESCRIPTION
Add the option to collapse our semantic representation for any expression involving a data plane variable. The reason we can do this is that, if we trait data plane variables as wild cards, the solver can find any satisfying assignment to most arithmetic expressions anyway.

Fixes #44. 