### PR TITLE
Support outputing optimized program after each update

### DIFF
--- a/core/flay_service.cpp
+++ b/core/flay_service.cpp
@@ -120,7 +120,8 @@ std::pair<int, bool> FlayServiceBase::elimControlPlaneDeadCode(
 }
 
 void FlayServiceWrapper::outputOptimizedProgram(std::filesystem::path optimizedOutputFileName) {
-    auto absoluteFilePath = FlayOptions::get().getOptimizedOutputDir().value() / optimizedOutputFileName;
+    auto absoluteFilePath =
+        FlayOptions::get().getOptimizedOutputDir().value() / optimizedOutputFileName;
     flayService.outputOptimizedProgram(absoluteFilePath);
     printInfo("Outputed optimized program to %1%", absoluteFilePath);
 }
@@ -176,7 +177,7 @@ int FlayServiceWrapper::run() {
     if (!controlPlaneUpdates.empty()) {
         printInfo("Processing control plane updates...");
     }
-    for (size_t updateIdx=0; updateIdx < controlPlaneUpdates.size(); updateIdx++) {
+    for (size_t updateIdx = 0; updateIdx < controlPlaneUpdates.size(); updateIdx++) {
         const auto &controlPlaneUpdate = controlPlaneUpdates[updateIdx];
         SymbolSet symbolSet;
         for (const auto &update : controlPlaneUpdate.updates()) {

--- a/core/flay_service.cpp
+++ b/core/flay_service.cpp
@@ -151,6 +151,7 @@ int FlayServiceWrapper::parseControlUpdatesFromPattern(const std::string &patter
         if (!entityOpt.has_value()) {
             return EXIT_FAILURE;
         }
+        controlPlaneUpdateFileNames.emplace_back(std::filesystem::path(file).filename());
         controlPlaneUpdates.emplace_back(entityOpt.value());
     }
     return EXIT_SUCCESS;
@@ -171,6 +172,9 @@ int FlayServiceWrapper::run() {
         return EXIT_FAILURE;
     }
     recordProgramChange(flayService);
+    if (FlayOptions::get().getOptimizedOutputDir() != std::nullopt) {
+        outputOptimizedProgram("before_updates.p4");
+    }
 
     /// Keeps track of how often the semantics have changed after an update.
     uint64_t semanticsChangeCounter = 0;
@@ -196,8 +200,8 @@ int FlayServiceWrapper::run() {
             semanticsChangeCounter++;
         }
         if (FlayOptions::get().getOptimizedOutputDir() != std::nullopt) {
-            std::filesystem::path fileName = "optimized." + std::to_string(updateIdx) + ".p4";
-            outputOptimizedProgram(fileName);
+            outputOptimizedProgram(std::filesystem::path(controlPlaneUpdateFileNames[updateIdx])
+                                       .replace_extension(".p4"));
         }
     }
 

--- a/core/flay_service.cpp
+++ b/core/flay_service.cpp
@@ -123,7 +123,7 @@ void FlayServiceWrapper::outputOptimizedProgram(std::filesystem::path optimizedO
     auto absoluteFilePath =
         FlayOptions::get().getOptimizedOutputDir().value() / optimizedOutputFileName;
     flayService.outputOptimizedProgram(absoluteFilePath);
-    printInfo("Outputed optimized program to %1%", absoluteFilePath);
+    printInfo("Wrote optimized program to %1%", absoluteFilePath);
 }
 
 std::vector<std::string> FlayServiceWrapper::findFiles(const std::string &pattern) {

--- a/core/flay_service.h
+++ b/core/flay_service.h
@@ -148,6 +148,7 @@ struct FlayServiceStatistics {
 /// Wrapper class to simplify benchmarking and the collection of statics.
 class FlayServiceWrapper {
     /// The series of control plane updates which is applied after Flay service has started.
+    std::vector<std::string> controlPlaneUpdateFileNames;
     std::vector<p4::v1::WriteRequest> controlPlaneUpdates;
 
  private:

--- a/flay.cpp
+++ b/flay.cpp
@@ -61,8 +61,8 @@ std::optional<FlayServiceStatistics> runServiceWrapper(const FlayOptions &flayOp
     }
 
     RETURN_IF_FALSE(serviceWrapper.run() == EXIT_SUCCESS, std::nullopt);
-    if (FlayOptions::get().getOptimizedOutputFile() != std::nullopt) {
-        serviceWrapper.outputOptimizedProgram(FlayOptions::get().getOptimizedOutputFile().value());
+    if (FlayOptions::get().getOptimizedOutputDir() != std::nullopt) {
+        serviceWrapper.outputOptimizedProgram("optimized.final.p4");
     }
     return serviceWrapper.getFlayServiceStatistics();
 }

--- a/options.cpp
+++ b/options.cpp
@@ -83,12 +83,12 @@ FlayOptions::FlayOptions(const std::string &message) : AbstractP4cToolOptions(me
         "In strict mode, Flay will report error upon adding more reachability condition for "
         "existing nodes");
     registerOption(
-        "--optimized-output-file", "optimizedOutputFile",
+        "--optimized-output-dir", "optimizedOutputDir",
         [this](const char *arg) {
-            optimizedOutputFile_ = std::filesystem::path(arg);
+            optimizedOutputDir_ = std::filesystem::path(arg);
             return true;
         },
-        "The path to the output file of the optimized P4 program.");
+        "The path to the output directory of the optimized P4 program(s).");
     registerOption(
         "--preserve-data-plane-variables", nullptr,
         [this](const char *) {
@@ -132,8 +132,8 @@ bool FlayOptions::usePlaceholders() const { return usePlaceholders_; }
 
 bool FlayOptions::isStrict() const { return strict_; }
 
-std::optional<std::filesystem::path> FlayOptions::getOptimizedOutputFile() const {
-    return optimizedOutputFile_;
+std::optional<std::filesystem::path> FlayOptions::getOptimizedOutputDir() const {
+    return optimizedOutputDir_;
 }
 
 bool FlayOptions::collapseDataPlaneOperations() const { return collapseDataPlaneOperations_; }

--- a/options.h
+++ b/options.h
@@ -51,7 +51,7 @@ class FlayOptions : public AbstractP4cToolOptions {
     [[nodiscard]] bool isStrict() const;
 
     /// @returns the path set with --optimized-output-file.
-    [[nodiscard]] std::optional<std::filesystem::path> getOptimizedOutputFile() const;
+    [[nodiscard]] std::optional<std::filesystem::path> getOptimizedOutputDir() const;
 
     /// @returns false when --preserve-data-plane-variables has been set.
     [[nodiscard]] bool collapseDataPlaneOperations() const;
@@ -87,7 +87,7 @@ class FlayOptions : public AbstractP4cToolOptions {
     bool strict_ = false;
 
     /// The path to the output file of the optimized P4 program.
-    std::optional<std::filesystem::path> optimizedOutputFile_ = std::nullopt;
+    std::optional<std::filesystem::path> optimizedOutputDir_ = std::nullopt;
 
     /// Collapse arithmetic operations on data plane variables.
     bool collapseDataPlaneOperations_ = true;


### PR DESCRIPTION
With this, Flay can output optimized programs into a specified directory, using file names in the format of "optimized.{updateIdx}.p4".