### PR TITLE
Fix a reachability calculation problem.

### DIFF
--- a/core/execution_state.cpp
+++ b/core/execution_state.cpp
@@ -136,9 +136,9 @@ void ExecutionState::addReachabilityMapping(const IR::Node *node, const IR::Expr
         return;
     }
 
-    bool isNewNode = reachabilityMap.initializeReachabilityMapping(
-        node, new IR::LAnd(getExecutionCondition(), cond), FlayOptions::get().isStrict());
-    if (!isNewNode && FlayOptions::get().isStrict()) {
+    bool notAlreadyInMap = reachabilityMap.initializeReachabilityMapping(
+        node, new IR::LAnd(getExecutionCondition(), cond));
+    if (!notAlreadyInMap && FlayOptions::get().isStrict()) {
         // Throw a fatal error if we try to add a duplicate mapping.
         // This can affect the correctness of the entire mapping.
         BUG("Reachability mapping for node %1% already exists. Every mapping must be uniquely "

--- a/core/expression_resolver.cpp
+++ b/core/expression_resolver.cpp
@@ -23,7 +23,9 @@ namespace P4Tools::Flay {
 
 ExpressionResolver::ExpressionResolver(const ProgramInfo &programInfo,
                                        ExecutionState &executionState)
-    : programInfo(programInfo), executionState(executionState) {}
+    : programInfo(programInfo), executionState(executionState) {
+    visitDagOnce = false;
+}
 
 const ProgramInfo &ExpressionResolver::getProgramInfo() const { return programInfo.get(); }
 

--- a/core/reachability.cpp
+++ b/core/reachability.cpp
@@ -23,7 +23,7 @@ ReachabilityExpression::ReachabilityExpression(const IR::Expression *cond)
     : cond(cond), reachabilityAssignment(std::nullopt) {}
 
 bool ReachabilityMap::initializeReachabilityMapping(const IR::Node *node,
-                                                    const IR::Expression *cond, bool addIfExist) {
+                                                    const IR::Expression *cond) {
     SymbolCollector collector;
     cond->apply(collector);
     const auto &collectedSymbols = collector.getCollectedSymbols();
@@ -32,16 +32,13 @@ bool ReachabilityMap::initializeReachabilityMapping(const IR::Node *node,
     }
 
     auto result = emplace(node, std::vector<ReachabilityExpression>());
-    if (!result.second && !addIfExist) {
-        return false;
-    }
-    result.first->second.push_back(ReachabilityExpression(cond));
+    result.first->second.emplace_back(cond);
     return result.second;
 }
 
 void ReachabilityMap::mergeReachabilityMapping(const ReachabilityMap &otherMap) {
     for (const auto &rechabilityTuple : otherMap) {
-        insert(rechabilityTuple);
+        (*this)[rechabilityTuple.first] = rechabilityTuple.second;
     }
     for (const auto &symbol : otherMap.getSymbolMap()) {
         symbolMap[symbol.first.get()].insert(symbol.second.begin(), symbol.second.end());

--- a/core/reachability.cpp
+++ b/core/reachability.cpp
@@ -113,17 +113,25 @@ std::optional<bool> SolverReachabilityMap::computeNodeReachability(
     return hasChanged;
 }
 
-std::optional<std::set<const ReachabilityExpression *>>
-SolverReachabilityMap::getReachabilityExpressions(const IR::Node *node) const {
+std::optional<bool> SolverReachabilityMap::isNodeReachable(const IR::Node *node) const {
     auto vectorIt = find(node);
     if (vectorIt != end()) {
         BUG_CHECK(!vectorIt->second.empty(), "Reachability vector for node %1% is empty.", node);
-        std::set<const ReachabilityExpression *> result;
-        for (const auto &it : vectorIt->second) {
-            result.emplace(it);
+        for (const auto &reachabilityNode : vectorIt->second) {
+            auto reachability = reachabilityNode->getReachability();
+            if (!reachability.has_value()) {
+                return std::nullopt;
+            }
+            if (reachability.value()) {
+                return true;
+            }
         }
-        return result;
+        return false;
     }
+    ::warning(
+        "Unable to find node %1% in the reachability map of this execution state. There might be "
+        "issues with the source information.",
+        node);
     return std::nullopt;
 }
 

--- a/core/reachability.h
+++ b/core/reachability.h
@@ -52,7 +52,7 @@ struct ReachabilityExpression {
 
 /// A mapping of P4C-IR nodes to their associated reachability expressions.
 class ReachabilityMap
-    : protected std::map<const IR::Node *, std::vector<ReachabilityExpression>, SourceIdCmp> {
+    : protected std::map<const IR::Node *, std::set<ReachabilityExpression *>, SourceIdCmp> {
     friend class Z3SolverReachabilityMap;
 
  private:
@@ -87,7 +87,7 @@ class AbstractReachabilityMap {
 
     /// @returns the reachability expression for the given node.
     /// @returns std::nullopt if no expression can be found.
-    [[nodiscard]] virtual std::optional<std::vector<const ReachabilityExpression *>>
+    [[nodiscard]] virtual std::optional<std::set<const ReachabilityExpression *>>
     getReachabilityExpressions(const IR::Node *node) const = 0;
 
     /// Compute reachability for all nodes in the map using the provided control plane constraints.
@@ -120,7 +120,7 @@ class SolverReachabilityMap : private ReachabilityMap, public AbstractReachabili
  public:
     explicit SolverReachabilityMap(AbstractSolver &solver, const ReachabilityMap &map);
 
-    std::optional<std::vector<const ReachabilityExpression *>> getReachabilityExpressions(
+    std::optional<std::set<const ReachabilityExpression *>> getReachabilityExpressions(
         const IR::Node *node) const override;
 
     std::optional<bool> recomputeReachability(

--- a/core/reachability.h
+++ b/core/reachability.h
@@ -85,11 +85,6 @@ class AbstractReachabilityMap {
     AbstractReachabilityMap() = default;
     virtual ~AbstractReachabilityMap() = default;
 
-    /// @returns the reachability expression for the given node.
-    /// @returns std::nullopt if no expression can be found.
-    [[nodiscard]] virtual std::optional<std::set<const ReachabilityExpression *>>
-    getReachabilityExpressions(const IR::Node *node) const = 0;
-
     /// Compute reachability for all nodes in the map using the provided control plane constraints.
     std::optional<bool> virtual recomputeReachability(
         const ControlPlaneConstraints &controlPlaneConstraints) = 0;
@@ -103,6 +98,11 @@ class AbstractReachabilityMap {
     /// constraints.
     std::optional<bool> virtual recomputeReachability(
         const NodeSet &targetNodes, const ControlPlaneConstraints &controlPlaneConstraints) = 0;
+
+    /// @return false when the node is never reachable,
+    /// true when the node is always reachable, and std::nullopt if the node is sometimes reachable
+    /// or the node could not be found.
+    virtual std::optional<bool> isNodeReachable(const IR::Node *node) const = 0;
 };
 
 class SolverReachabilityMap : private ReachabilityMap, public AbstractReachabilityMap {
@@ -120,9 +120,6 @@ class SolverReachabilityMap : private ReachabilityMap, public AbstractReachabili
  public:
     explicit SolverReachabilityMap(AbstractSolver &solver, const ReachabilityMap &map);
 
-    std::optional<std::set<const ReachabilityExpression *>> getReachabilityExpressions(
-        const IR::Node *node) const override;
-
     std::optional<bool> recomputeReachability(
         const ControlPlaneConstraints &controlPlaneConstraints) override;
 
@@ -133,6 +130,8 @@ class SolverReachabilityMap : private ReachabilityMap, public AbstractReachabili
     std::optional<bool> recomputeReachability(
         const NodeSet &targetNodes,
         const ControlPlaneConstraints &controlPlaneConstraints) override;
+
+    std::optional<bool> isNodeReachable(const IR::Node *node) const override;
 };
 
 }  // namespace P4Tools::Flay

--- a/core/reachability.h
+++ b/core/reachability.h
@@ -63,8 +63,7 @@ class ReachabilityMap
  public:
     /// Initialize the reachability mapping for the given node.
     /// @returns false if the node is already mapped.
-    bool initializeReachabilityMapping(const IR::Node *node, const IR::Expression *cond,
-                                       bool addIfExist = false);
+    bool initializeReachabilityMapping(const IR::Node *node, const IR::Expression *cond);
 
     /// Merge an other reachability map into this reachability map.
     void mergeReachabilityMapping(const ReachabilityMap &otherMap);

--- a/core/stepper.cpp
+++ b/core/stepper.cpp
@@ -16,7 +16,9 @@
 namespace P4Tools::Flay {
 
 FlayStepper::FlayStepper(const ProgramInfo &programInfo, ExecutionState &executionState)
-    : programInfo(programInfo), executionState(executionState) {}
+    : programInfo(programInfo), executionState(executionState) {
+    visitDagOnce = false;
+}
 
 const ProgramInfo &FlayStepper::getProgramInfo() const { return programInfo.get(); }
 

--- a/core/table_executor.cpp
+++ b/core/table_executor.cpp
@@ -1,10 +1,8 @@
 
 #include "backends/p4tools/modules/flay/core/table_executor.h"
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdio>
-#include <utility>
 
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/core/z3solver_reachability.cpp
+++ b/core/z3solver_reachability.cpp
@@ -19,9 +19,9 @@ std::optional<bool> Z3SolverReachabilityMap::computeNodeReachability(const IR::N
         return std::nullopt;
     }
     bool hasChanged = false;
-    for (auto &it : vectorIt->second) {
-        auto reachabilityCondition = it.getZ3Condition();
-        auto reachabilityAssignment = it.getReachability();
+    for (const auto &it : vectorIt->second) {
+        const auto &reachabilityCondition = it->getZ3Condition();
+        auto reachabilityAssignment = it->getReachability();
         {
             solver.push();
             solver.asrt(reachabilityCondition);
@@ -36,7 +36,7 @@ std::optional<bool> Z3SolverReachabilityMap::computeNodeReachability(const IR::N
 
             /// There is no way to satisfy the condition. It is always false.
             if (!solverResult.value()) {
-                it.setReachability(false);
+                it->setReachability(false);
                 hasChanged = !reachabilityAssignment.has_value() || reachabilityAssignment.value();
                 continue;
             }
@@ -54,13 +54,13 @@ std::optional<bool> Z3SolverReachabilityMap::computeNodeReachability(const IR::N
             }
             /// There is no way to falsify the condition. It is always true.
             if (!solverResult.value()) {
-                it.setReachability(true);
+                it->setReachability(true);
                 hasChanged = !reachabilityAssignment.has_value() || !reachabilityAssignment.value();
                 continue;
             }
 
             if (solverResult.value() && solverResult.value()) {
-                it.setReachability(std::nullopt);
+                it->setReachability(std::nullopt);
                 hasChanged = reachabilityAssignment.has_value();
             }
         }
@@ -73,24 +73,24 @@ Z3SolverReachabilityMap::Z3SolverReachabilityMap(const ReachabilityMap &map)
     Util::ScopedTimer timer("Precomputing Z3 Reachability");
     Z3Translator z3Translator(solver);
     for (const auto &[node, reachabilityExpressionVector] : map) {
-        std::vector<Z3ReachabilityExpression> result;
-        for (auto &reachabilityExpression : reachabilityExpressionVector) {
-            reachabilityExpression.getCondition()->apply(z3Translator);
-            result.push_back(
-                Z3ReachabilityExpression(reachabilityExpression, z3Translator.getResult()));
+        std::set<Z3ReachabilityExpression *> result;
+        for (const auto &reachabilityExpression : reachabilityExpressionVector) {
+            reachabilityExpression->getCondition()->apply(z3Translator);
+            result.emplace(
+                new Z3ReachabilityExpression(*reachabilityExpression, z3Translator.getResult()));
         }
-        this->insert({node, result});
+        (*this)[node].insert(result.begin(), result.end());
     }
 }
 
-std::optional<std::vector<const ReachabilityExpression *>>
+std::optional<std::set<const ReachabilityExpression *>>
 Z3SolverReachabilityMap::getReachabilityExpressions(const IR::Node *node) const {
     auto vectorIt = find(node);
     if (vectorIt != end()) {
         BUG_CHECK(!vectorIt->second.empty(), "Reachability vector for node %1% is empty.", node);
-        std::vector<const ReachabilityExpression *> result;
-        for (auto &it : vectorIt->second) {
-            result.push_back(&it);
+        std::set<const ReachabilityExpression *> result;
+        for (const auto &it : vectorIt->second) {
+            result.emplace(it);
         }
         return result;
     }

--- a/core/z3solver_reachability.h
+++ b/core/z3solver_reachability.h
@@ -24,7 +24,7 @@ class Z3ReachabilityExpression : public ReachabilityExpression {
 };
 
 class Z3SolverReachabilityMap
-    : private std::map<const IR::Node *, std::vector<Z3ReachabilityExpression>, SourceIdCmp>,
+    : private std::map<const IR::Node *, std::set<Z3ReachabilityExpression *>, SourceIdCmp>,
       public AbstractReachabilityMap {
     /// A mapping of symbolic variables to IR nodes that depend on these symbolic variables in the
     /// reachability map. This map can we used for incremental re-computation of reachability.
@@ -39,7 +39,7 @@ class Z3SolverReachabilityMap
  public:
     explicit Z3SolverReachabilityMap(const ReachabilityMap &map);
 
-    std::optional<std::vector<const ReachabilityExpression *>> getReachabilityExpressions(
+    std::optional<std::set<const ReachabilityExpression *>> getReachabilityExpressions(
         const IR::Node *node) const override;
 
     std::optional<bool> recomputeReachability(

--- a/core/z3solver_reachability.h
+++ b/core/z3solver_reachability.h
@@ -39,9 +39,6 @@ class Z3SolverReachabilityMap
  public:
     explicit Z3SolverReachabilityMap(const ReachabilityMap &map);
 
-    std::optional<std::set<const ReachabilityExpression *>> getReachabilityExpressions(
-        const IR::Node *node) const override;
-
     std::optional<bool> recomputeReachability(
         const ControlPlaneConstraints &controlPlaneConstraints) override;
 
@@ -52,6 +49,8 @@ class Z3SolverReachabilityMap
     std::optional<bool> recomputeReachability(
         const NodeSet &targetNodes,
         const ControlPlaneConstraints &controlPlaneConstraints) override;
+
+    std::optional<bool> isNodeReachable(const IR::Node *node) const override;
 };
 
 }  // namespace P4Tools::Flay

--- a/passes/elim_dead_code.cpp
+++ b/passes/elim_dead_code.cpp
@@ -16,7 +16,7 @@ ElimDeadCode::ElimDeadCode(const P4::ReferenceMap &refMap,
     : reachabilityMap(reachabilityMap), refMap(refMap) {}
 
 std::optional<bool> ElimDeadCode::getAnyReachability(
-    const std::vector<const ReachabilityExpression *> &condVector) {
+    const std::set<const ReachabilityExpression *> &condVector) {
     for (const auto *condition : condVector) {
         auto reachability = condition->getReachability();
         if (!reachability.has_value()) {

--- a/passes/elim_dead_code.cpp
+++ b/passes/elim_dead_code.cpp
@@ -15,20 +15,6 @@ ElimDeadCode::ElimDeadCode(const P4::ReferenceMap &refMap,
                            const AbstractReachabilityMap &reachabilityMap)
     : reachabilityMap(reachabilityMap), refMap(refMap) {}
 
-std::optional<bool> ElimDeadCode::getAnyReachability(
-    const std::set<const ReachabilityExpression *> &condVector) {
-    for (const auto *condition : condVector) {
-        auto reachability = condition->getReachability();
-        if (!reachability.has_value()) {
-            return std::nullopt;
-        }
-        if (reachability.value()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 const IR::Node *ElimDeadCode::preorder(IR::IfStatement *stmt) {
     // Only analyze statements with valid source location.
     if (!stmt->srcInfo.isValid()) {
@@ -40,17 +26,7 @@ const IR::Node *ElimDeadCode::preorder(IR::IfStatement *stmt) {
         return stmt;
     }
 
-    auto conditionVectorOpt = reachabilityMap.get().getReachabilityExpressions(stmt);
-    if (!conditionVectorOpt.has_value()) {
-        ::warning(
-            "Unable to find node %1% in the reachability map of this execution "
-            "state. There might "
-            "be "
-            "issues with the source information.",
-            stmt);
-        return stmt;
-    }
-    auto reachability = getAnyReachability(conditionVectorOpt.value());
+    auto reachability = reachabilityMap.get().isNodeReachable(stmt);
 
     // Ambiguous condition, we can not simplify.
     if (!reachability.has_value()) {
@@ -91,15 +67,7 @@ const IR::Node *ElimDeadCode::preorder(IR::SwitchStatement *switchStmt) {
             filteredSwitchCases.push_back(switchCase);
             break;
         }
-        auto conditionVectorOpt = reachabilityMap.get().getReachabilityExpressions(switchCase);
-        if (!conditionVectorOpt.has_value()) {
-            ::warning(
-                "Unable to find node %1% in the reachability map of this execution state. There "
-                "might be issues with the source information.",
-                switchCase);
-            return switchCase;
-        }
-        auto isreachabilityOpt = getAnyReachability(conditionVectorOpt.value());
+        auto isreachabilityOpt = reachabilityMap.get().isNodeReachable(switchCase);
         if (!isreachabilityOpt.has_value()) {
             filteredSwitchCases.push_back(switchCase);
             continue;
@@ -157,15 +125,8 @@ const IR::Node *ElimDeadCode::preorder(IR::Member *member) {
     if (member->member != IR::Type_Table::hit && member->member != IR::Type_Table::miss) {
         return member;
     }
-    const auto conditionVectorOpt = reachabilityMap.get().getReachabilityExpressions(member);
-    if (!conditionVectorOpt.has_value()) {
-        ::warning(
-            "Unable to find node %1% in the reachability map of this execution state. There "
-            "might be issues with the source information.",
-            member);
-        return member;
-    }
-    ASSIGN_OR_RETURN(auto reachability, getAnyReachability(conditionVectorOpt.value()), member);
+
+    ASSIGN_OR_RETURN(auto reachability, reachabilityMap.get().isNodeReachable(member), member);
 
     const auto *result = IR::getBoolLiteral(reachability, member->srcInfo);
     printInfo("%1% can be replaced with %2%.", member, result->toString());
@@ -193,16 +154,8 @@ const IR::Node *ElimDeadCode::preorder(IR::MethodCallStatement *stmt) {
     // Filter out any actions which are @defaultonly.
     auto tableActionList = TableUtils::buildTableActionList(table);
     for (const auto *action : tableActionList) {
-        const auto conditionVectorOpt = reachabilityMap.get().getReachabilityExpressions(action);
-        if (!conditionVectorOpt.has_value()) {
-            ::warning(
-                "Unable to find node %1% in the reachability map of this execution state. There "
-                "might be issues with the source information.",
-                action);
-            return stmt;
-        }
         // We return if a single action is executable for the current table.
-        ASSIGN_OR_RETURN(auto reachability, getAnyReachability(conditionVectorOpt.value()), stmt);
+        ASSIGN_OR_RETURN(auto reachability, reachabilityMap.get().isNodeReachable(action), stmt);
 
         if (reachability) {
             printInfo("%1% will always be executed.", action);

--- a/passes/elim_dead_code.h
+++ b/passes/elim_dead_code.h
@@ -43,7 +43,7 @@ class ElimDeadCode : public Transform {
     /// @return true if any of the condition is reachable; false if none of the conditions are
     /// reachable; std::nullopt if the reachability is ambiguous.
     static std::optional<bool> getAnyReachability(
-        const std::vector<const ReachabilityExpression *> &condVector);
+        const std::set<const ReachabilityExpression *> &condVector);
 
     [[nodiscard]] std::vector<EliminatedReplacedPair> getEliminatedNodes() const;
 };

--- a/targets/bmv2/test/testdata/issue3374.ref
+++ b/targets/bmv2/test/testdata/issue3374.ref
@@ -1,2 +1,2 @@
-Eliminated node at line 128: 12w1: { stub.apply();}
-Eliminated node at line 129: 12w2: {
+Replaced node at line 128: 12w1: { stub.apply();} with const default_action = execute;
+Replaced node at line 131: stub1.apply(); with const default_action = execute_1;


### PR DESCRIPTION
When merging execution state back, reachability was not correctly transferred. Instead of a vector we use a set of pointers for reachability expressions. This way we can merge sets back by comparing the pointers. 