### PR TITLE
Add an option to skip the parser for Flay analysis.

### DIFF
--- a/core/simplify_expression.cpp
+++ b/core/simplify_expression.cpp
@@ -179,7 +179,8 @@ const IR::Expression *simplify(const IR::Expression *expr) {
         new FoldMuxConditionDown(),
         new LiftMuxConditions(),
     });
-    if (FlayOptions::get().collapseDataPlaneOperations()) {
+    auto &options = FlayOptions::get();
+    if (options.collapseDataPlaneOperations() && !options.skipParsers()) {
         pass.addPasses({
             new Flay::DataPlaneVariablePropagator(),
         });

--- a/options.cpp
+++ b/options.cpp
@@ -156,6 +156,14 @@ FlayOptions::FlayOptions(const std::string &message)
             }
         },
         "Specifies the control plane API to use. Defaults to P4Rtuntime.");
+    registerOption(
+        "--skip-parsers", nullptr,
+        [this](const char *) {
+            _skipParsers = true;
+            return true;
+        },
+        "Skip parsers in the analysis and replace the parser output result with symbolic "
+        "variables.");
 }
 
 std::filesystem::path FlayOptions::controlPlaneConfig() const {
@@ -189,5 +197,7 @@ std::optional<std::filesystem::path> FlayOptions::p4InfoFilePath() const { retur
 std::optional<std::filesystem::path> FlayOptions::userP4Info() const { return _userP4Info; }
 
 std::string_view FlayOptions::controlPlaneApi() const { return _controlPlaneApi; }
+
+bool FlayOptions::skipParsers() const { return _skipParsers; }
 
 }  // namespace P4Tools

--- a/options.h
+++ b/options.h
@@ -65,6 +65,9 @@ class FlayOptions : public AbstractP4cToolOptions {
     /// @returns the control plane API to use.
     [[nodiscard]] std::string_view controlPlaneApi() const;
 
+    /// @returns true when the --skip-parsers option has been set.
+    [[nodiscard]] bool skipParsers() const;
+
  protected:
     explicit FlayOptions(
         const std::string &message = "Remove control-plane dead code from a P4 program.");
@@ -106,6 +109,9 @@ class FlayOptions : public AbstractP4cToolOptions {
 
     // The control plane API to use. Defaults to P4Runtime.
     std::string _controlPlaneApi = "P4RUNTIME";
+
+    /// Skip parsers in the analysis and replace the parser output result with symbolic variables.
+    bool _skipParsers = false;
 };
 
 }  // namespace P4Tools

--- a/passes/elim_dead_code.cpp
+++ b/passes/elim_dead_code.cpp
@@ -5,6 +5,7 @@
 #include "backends/p4tools/common/lib/logging.h"
 #include "backends/p4tools/common/lib/table_utils.h"
 #include "backends/p4tools/modules/flay/control_plane/return_macros.h"
+#include "backends/p4tools/modules/flay/options.h"
 #include "ir/node.h"
 #include "ir/vector.h"
 #include "lib/error.h"
@@ -14,6 +15,13 @@ namespace P4Tools::Flay {
 ElimDeadCode::ElimDeadCode(const P4::ReferenceMap &refMap,
                            const AbstractReachabilityMap &reachabilityMap)
     : reachabilityMap(reachabilityMap), refMap(refMap) {}
+
+const IR::Node *ElimDeadCode::preorder(IR::P4Parser *parser) {
+    if (FlayOptions::get().skipParsers()) {
+        prune();
+    }
+    return parser;
+}
 
 const IR::Node *ElimDeadCode::preorder(IR::IfStatement *stmt) {
     // Only analyze statements with valid source location.

--- a/passes/elim_dead_code.h
+++ b/passes/elim_dead_code.h
@@ -29,6 +29,7 @@ class ElimDeadCode : public Transform {
     /// The list of eliminated and optionally replaced nodes. Used for bookkeeping.
     std::vector<EliminatedReplacedPair> eliminatedNodes;
 
+    const IR::Node *preorder(IR::P4Parser *parser) override;
     const IR::Node *preorder(IR::IfStatement *stmt) override;
     const IR::Node *preorder(IR::SwitchStatement *switchStmt) override;
     const IR::Node *preorder(IR::MethodCallStatement *stmt) override;

--- a/targets/tofino/base/stepper.cpp
+++ b/targets/tofino/base/stepper.cpp
@@ -27,6 +27,22 @@ void TofinoBaseFlayStepper::initializeState() {
         executionState.initializeBlockParams(target, typeDecl, &archMember->blockParams);
         blockIdx++;
     }
+    // Make the ingress and egress parser error symbolic, it may not always be set by the parser.
+    const auto *sixteenBitType = IR::Type_Bits::get(16);
+    {
+        const auto *parserErrorVar = new IR::Member(
+            sixteenBitType, new IR::PathExpression("*ig_intr_md_from_prsr"), "parser_err");
+        const IR::Expression *parserErrorValue =
+            new IR::SymbolicVariable(sixteenBitType, "ig_intr_md_from_prsr.parser_err");
+        getExecutionState().set(parserErrorVar, parserErrorValue);
+    }
+    {
+        const auto *parserErrorVar = new IR::Member(
+            sixteenBitType, new IR::PathExpression("*eg_intr_md_from_prsr"), "parser_err");
+        const IR::Expression *parserErrorValue =
+            new IR::SymbolicVariable(sixteenBitType, "eg_intr_md_from_prsr.parser_err");
+        getExecutionState().set(parserErrorVar, parserErrorValue);
+    }
 }
 
 TofinoBaseFlayStepper::TofinoBaseFlayStepper(const TofinoBaseProgramInfo &programInfo,

--- a/targets/tofino/test/testdata/scion.ref
+++ b/targets/tofino/test/testdata/scion.ref
@@ -1,4 +1,3 @@
-Eliminated node at line 1267: if (ig_prsr_md.parser_err != PARSER_ERROR_OK) {
 Eliminated node at line 1272: bool local_destination = tbl_check_local.apply().hit;
 Eliminated node at line 1279: hdr.scion_hop_1.mac = hdr.bridge.hop_field_1.hop_field.mac;
 Eliminated node at line 1330: tbl_select_accelerator.apply();
@@ -16,6 +15,6 @@ Eliminated node at line 1536: if(hdr.scion_common.pathType == PathType.SCION) {
 Replaced node at line 1548: tbl_set_local_source.apply(); with default_action = drop();
 Eliminated node at line 1551: if (hdr.scion_common.nextHdr != 0xCB) {
 statement_count_before:596
-statement_count_after:571
+statement_count_after:572
 cyclomatic_complexity:134
 

--- a/targets/tofino/tofino1/stepper.cpp
+++ b/targets/tofino/tofino1/stepper.cpp
@@ -1,7 +1,5 @@
 #include "backends/p4tools/modules/flay/targets/tofino/tofino1/stepper.h"
 
-#include <utility>
-
 #include "backends/p4tools/common/lib/variables.h"
 #include "backends/p4tools/modules/flay/core/program_info.h"
 
@@ -21,12 +19,6 @@ Tofino1ExpressionResolver &Tofino1FlayStepper::createExpressionResolver(
 }
 
 void Tofino1FlayStepper::initializeParserState(const IR::P4Parser &parser) {
-    // TODO: In Tofino blocks can have optional elements. How to support setting the parser error
-    // for that?
-
-    // Both parsers have 6 parameters.
-    // BUG_CHECK(parser.getApplyParameters()->parameters.size() == 6,
-    //           "Expected 6 parameters for parser %1%", parser);
     const auto &parameters = parser.getApplyParameters()->parameters;
 
     auto canonicalBlockName = getProgramInfo().getCanonicalBlockName(parser.name);
@@ -45,12 +37,6 @@ void Tofino1FlayStepper::initializeParserState(const IR::P4Parser &parser) {
                 parser.controlPlaneName() + "_" + metadataBlock->controlPlaneName() + "_parser_err";
             getExecutionState().set(parserErrorVariable, ToolsVariables::getSymbolicVariable(
                                                              sixteenBitType, parserErrorLabel));
-        } else {
-            const auto *parserErrorVar = new IR::Member(
-                sixteenBitType, new IR::PathExpression("*ig_intr_md_from_prsr"), "parser_err");
-            const IR::Expression *parserErrorValue =
-                new IR::SymbolicVariable(sixteenBitType, "ig_intr_md_from_prsr.parser_err");
-            getExecutionState().set(parserErrorVar, parserErrorValue);
         }
     } else if (canonicalBlockName == "EgressParserT") {
         constexpr int kParserMetadataIndex = 4;
@@ -66,12 +52,6 @@ void Tofino1FlayStepper::initializeParserState(const IR::P4Parser &parser) {
                 parser.controlPlaneName() + "_" + metadataBlock->controlPlaneName() + "_parser_err";
             getExecutionState().set(parserErrorVariable, ToolsVariables::getSymbolicVariable(
                                                              sixteenBitType, parserErrorLabel));
-        } else {
-            const auto *parserErrorVar = new IR::Member(
-                sixteenBitType, new IR::PathExpression("*eg_intr_md_from_prsr"), "parser_err");
-            const IR::Expression *parserErrorValue =
-                new IR::SymbolicVariable(sixteenBitType, "eg_intr_md_from_prsr.parser_err");
-            getExecutionState().set(parserErrorVar, parserErrorValue);
         }
     } else {
         BUG("Unexpected canonical block name %1% for parser %2%", canonicalBlockName, parser);


### PR DESCRIPTION
With the option `--skip-parsers` we can now skip the parser. This can greatly speed up analysis in some case without reducing precision. 