### PR TITLE
Actually initialize parser errors in the Flay back ends.

### DIFF
--- a/core/parser_stepper.cpp
+++ b/core/parser_stepper.cpp
@@ -48,6 +48,8 @@ bool ParserStepper::preorder(const IR::P4Parser *parser) {
         executionState.copyIn(FlayTarget::get(), internalParam, externalParamName);
     }
 
+    stepper.get().initializeParserState(*parser);
+
     // Declare local variables.
     for (const auto *decl : parser->parserLocals) {
         if (const auto *declVar = decl->to<IR::Declaration_Variable>()) {

--- a/core/stepper.cpp
+++ b/core/stepper.cpp
@@ -29,6 +29,10 @@ bool FlayStepper::preorder(const IR::Node *node) {
                       node->node_type_name());
 }
 
+void FlayStepper::initializeParserState(const IR::P4Parser & /*parser*/) {};
+
+void FlayStepper::initializeControlState(const IR::P4Control & /*control*/) {};
+
 /* =============================================================================================
  *  Visitor functions
  * ============================================================================================= */
@@ -55,6 +59,8 @@ bool FlayStepper::preorder(const IR::P4Control *control) {
         auto externalParamName = archSpec->getParamName(canonicalName, paramIdx);
         executionState.copyIn(FlayTarget::get(), internalParam, externalParamName);
     }
+
+    initializeControlState(*control);
 
     // Declare local variables.
     for (const auto *decl : control->controlLocals) {

--- a/core/stepper.h
+++ b/core/stepper.h
@@ -26,6 +26,14 @@ class FlayStepper : public Inspector {
     std::reference_wrapper<ExecutionState> _executionState;
 
  protected:
+    /// Called after the copy-in step in the parser.
+    /// Can initialize some target-specific state before the rest of the parser is invoked.
+    virtual void initializeParserState(const IR::P4Parser &parser);
+
+    /// Called after the copy-in step in the control.
+    /// Can initialize some target-specific state before the rest of the control is invoked.
+    virtual void initializeControlState(const IR::P4Control &control);
+
     /// Visitor methods.
     bool preorder(const IR::Node *node) override;
     bool preorder(const IR::P4Control *control) override;

--- a/targets/bmv2/stepper.h
+++ b/targets/bmv2/stepper.h
@@ -19,6 +19,8 @@ class V1ModelFlayStepper : public FlayStepper {
 
     void initializeState() override;
 
+    void initializeParserState(const IR::P4Parser &parser) override;
+
     V1ModelExpressionResolver &createExpressionResolver(
         const ProgramInfo &programInfo, ExecutionState &executionState) const override;
 };

--- a/targets/bmv2/test/testdata/checksum2-bmv2.ref
+++ b/targets/bmv2/test/testdata/checksum2-bmv2.ref
@@ -1,5 +1,5 @@
-Eliminated node at line 132: if (stdmeta.parser_error != error.NoError) {
+
 statement_count_before:13
-statement_count_after:12
+statement_count_after:13
 cyclomatic_complexity:5
 

--- a/targets/bmv2/test/testdata/checksum3-bmv2.ref
+++ b/targets/bmv2/test/testdata/checksum3-bmv2.ref
@@ -1,6 +1,5 @@
 Eliminated node at line 128: if (stdmeta.checksum_error == 1) {
-Eliminated node at line 132: if (stdmeta.parser_error != error.NoError) {
 statement_count_before:13
-statement_count_after:11
+statement_count_after:12
 cyclomatic_complexity:5
 

--- a/targets/bmv2/test/testdata/issue1768-bmv2.ref
+++ b/targets/bmv2/test/testdata/issue1768-bmv2.ref
@@ -1,5 +1,5 @@
-Eliminated node at line 31: if (standard_metadata.parser_error != error.NoError)
+
 statement_count_before:2
-statement_count_after:1
+statement_count_after:2
 cyclomatic_complexity:1
 

--- a/targets/bmv2/test/testdata/issue1824-bmv2.ref
+++ b/targets/bmv2/test/testdata/issue1824-bmv2.ref
@@ -1,5 +1,5 @@
-Eliminated node at line 51: if (stdmeta.parser_error != error.NoError) {
+
 statement_count_before:5
-statement_count_after:4
+statement_count_after:5
 cyclomatic_complexity:1
 

--- a/targets/bmv2/test/testdata/parser_error-bmv2.ref
+++ b/targets/bmv2/test/testdata/parser_error-bmv2.ref
@@ -1,5 +1,5 @@
-Eliminated node at line 29: if (standard_metadata.parser_error == error.PacketTooShort) {
+
 statement_count_before:7
-statement_count_after:3
+statement_count_after:7
 cyclomatic_complexity:1
 

--- a/targets/bmv2/test/testdata/test-parserinvalidargument-error-bmv2.ref
+++ b/targets/bmv2/test/testdata/test-parserinvalidargument-error-bmv2.ref
@@ -1,5 +1,5 @@
-Eliminated node at line 69: } else if (stdmeta.parser_error == error.PacketTooShort) {
+
 statement_count_before:13
-statement_count_after:6
+statement_count_after:13
 cyclomatic_complexity:7
 

--- a/targets/fpga/test/testdata/p4_and_verilog.ref
+++ b/targets/fpga/test/testdata/p4_and_verilog.ref
@@ -1,6 +1,5 @@
-Eliminated node at line 81: if (smeta.parser_error != error.NoError) {
 Eliminated node at line 89: forward.apply();
 statement_count_before:13
-statement_count_after:10
+statement_count_after:12
 cyclomatic_complexity:6
 

--- a/targets/fpga/test/testdata/p4_hbm.ref
+++ b/targets/fpga/test/testdata/p4_hbm.ref
@@ -1,6 +1,5 @@
-Eliminated node at line 173: if (smeta.parser_error != error.NoError) {
 Eliminated node at line 188: filter.apply();
 statement_count_before:20
-statement_count_after:17
+statement_count_after:19
 cyclomatic_complexity:23
 

--- a/targets/fpga/test/testdata/p4_multi_proc_egr.ref
+++ b/targets/fpga/test/testdata/p4_multi_proc_egr.ref
@@ -1,6 +1,5 @@
-Eliminated node at line 81: if (smeta.parser_error != error.NoError) {
 Eliminated node at line 89: forward.apply();
 statement_count_before:13
-statement_count_after:10
+statement_count_after:12
 cyclomatic_complexity:6
 

--- a/targets/fpga/test/testdata/p4_multi_proc_igr.ref
+++ b/targets/fpga/test/testdata/p4_multi_proc_igr.ref
@@ -1,6 +1,5 @@
-Eliminated node at line 88: if (smeta.parser_error != error.NoError) {
 Eliminated node at line 96: forward.apply();
 statement_count_before:15
-statement_count_after:12
+statement_count_after:14
 cyclomatic_complexity:6
 

--- a/targets/fpga/test/testdata/p4_only.ref
+++ b/targets/fpga/test/testdata/p4_only.ref
@@ -1,6 +1,5 @@
-Eliminated node at line 81: if (smeta.parser_error != error.NoError) {
 Eliminated node at line 89: forward.apply();
 statement_count_before:13
-statement_count_after:10
+statement_count_after:12
 cyclomatic_complexity:6
 

--- a/targets/fpga/test/testdata/p4_with_extern.ref
+++ b/targets/fpga/test/testdata/p4_with_extern.ref
@@ -1,6 +1,5 @@
-Eliminated node at line 88: if (smeta.parser_error != error.NoError) {
 Eliminated node at line 96: forward.apply();
 statement_count_before:15
-statement_count_after:12
+statement_count_after:14
 cyclomatic_complexity:6
 

--- a/targets/fpga/xsa/stepper.cpp
+++ b/targets/fpga/xsa/stepper.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "backends/p4tools/common/lib/variables.h"
 #include "backends/p4tools/modules/flay/core/program_info.h"
 
 namespace P4Tools::Flay::Fpga {
@@ -16,6 +17,20 @@ XsaFlayStepper::XsaFlayStepper(const XsaProgramInfo &programInfo, ExecutionState
 XsaExpressionResolver &XsaFlayStepper::createExpressionResolver(
     const ProgramInfo &programInfo, ExecutionState &executionState) const {
     return *new XsaExpressionResolver(programInfo, executionState);
+}
+
+void XsaFlayStepper::initializeParserState(const IR::P4Parser &parser) {
+    BUG_CHECK(parser.getApplyParameters()->parameters.size() == 4,
+              "Expected 4 parameters for parser %1%", parser);
+    // Initialize the parser error to be a symbolic variable.
+    const auto *metadataBlock = parser.getApplyParameters()->parameters.at(3);
+    const auto *thirtyTwoBitType = IR::Type_Bits::get(32);
+    auto *parserErrorVariable = new IR::Member(
+        thirtyTwoBitType, new IR::PathExpression(metadataBlock->name), "parser_error");
+    auto parserErrorLabel =
+        parser.controlPlaneName() + "_" + metadataBlock->controlPlaneName() + "_parser_error";
+    getExecutionState().set(parserErrorVariable, ToolsVariables::getSymbolicVariable(
+                                                     thirtyTwoBitType, parserErrorLabel));
 }
 
 }  // namespace P4Tools::Flay::Fpga

--- a/targets/fpga/xsa/stepper.h
+++ b/targets/fpga/xsa/stepper.h
@@ -16,6 +16,8 @@ class XsaFlayStepper : public FpgaBaseFlayStepper {
  public:
     explicit XsaFlayStepper(const XsaProgramInfo &programInfo, ExecutionState &executionState);
 
+    void initializeParserState(const IR::P4Parser &parser) override;
+
     XsaExpressionResolver &createExpressionResolver(const ProgramInfo &programInfo,
                                                     ExecutionState &executionState) const override;
 };

--- a/targets/tofino/base/stepper.cpp
+++ b/targets/tofino/base/stepper.cpp
@@ -13,28 +13,6 @@ const TofinoBaseProgramInfo &TofinoBaseFlayStepper::getProgramInfo() const {
     return *FlayStepper::getProgramInfo().checkedTo<TofinoBaseProgramInfo>();
 }
 
-bool TofinoBaseFlayStepper::preorder(const IR::P4Control *control) {
-    // Set the parser error to a symbolic variable before stepping into the control.
-    // TODO: This is imprecise. We should be able to set the parser error to the right value in the
-    // parser.
-    const auto *sixteenBitType = IR::Type_Bits::get(16);
-    {
-        const auto *parserErrorVar = new IR::Member(
-            sixteenBitType, new IR::PathExpression("*ig_intr_md_from_prsr"), "parser_err");
-        const IR::Expression *parserErrorValue =
-            new IR::SymbolicVariable(sixteenBitType, "ig_intr_md_from_prsr.parser_err");
-        getExecutionState().set(parserErrorVar, parserErrorValue);
-    }
-    {
-        const auto *parserErrorVar = new IR::Member(
-            sixteenBitType, new IR::PathExpression("*eg_intr_md_from_prsr"), "parser_err");
-        const IR::Expression *parserErrorValue =
-            new IR::SymbolicVariable(sixteenBitType, "eg_intr_md_from_prsr.parser_err");
-        getExecutionState().set(parserErrorVar, parserErrorValue);
-    }
-    return FlayStepper::preorder(control);
-}
-
 void TofinoBaseFlayStepper::initializeState() {
     const auto &target = FlayTarget::get();
     const auto *archSpec = FlayTarget::getArchSpec();

--- a/targets/tofino/base/stepper.h
+++ b/targets/tofino/base/stepper.h
@@ -11,8 +11,6 @@ class TofinoBaseFlayStepper : public FlayStepper {
  protected:
     const TofinoBaseProgramInfo &getProgramInfo() const override;
 
-    bool preorder(const IR::P4Control *control) override;
-
  public:
     explicit TofinoBaseFlayStepper(const TofinoBaseProgramInfo &programInfo,
                                    ExecutionState &executionState);

--- a/targets/tofino/test/testdata/scion.ref
+++ b/targets/tofino/test/testdata/scion.ref
@@ -1,3 +1,4 @@
+Eliminated node at line 1267: if (ig_prsr_md.parser_err != PARSER_ERROR_OK) {
 Eliminated node at line 1272: bool local_destination = tbl_check_local.apply().hit;
 Eliminated node at line 1279: hdr.scion_hop_1.mac = hdr.bridge.hop_field_1.hop_field.mac;
 Eliminated node at line 1330: tbl_select_accelerator.apply();
@@ -15,6 +16,6 @@ Eliminated node at line 1536: if(hdr.scion_common.pathType == PathType.SCION) {
 Replaced node at line 1548: tbl_set_local_source.apply(); with default_action = drop();
 Eliminated node at line 1551: if (hdr.scion_common.nextHdr != 0xCB) {
 statement_count_before:596
-statement_count_after:572
+statement_count_after:571
 cyclomatic_complexity:134
 

--- a/targets/tofino/tofino1/stepper.cpp
+++ b/targets/tofino/tofino1/stepper.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "backends/p4tools/common/lib/variables.h"
 #include "backends/p4tools/modules/flay/core/program_info.h"
 
 namespace P4Tools::Flay::Tofino {
@@ -17,6 +18,64 @@ Tofino1FlayStepper::Tofino1FlayStepper(const Tofino1ProgramInfo &programInfo,
 Tofino1ExpressionResolver &Tofino1FlayStepper::createExpressionResolver(
     const ProgramInfo &programInfo, ExecutionState &executionState) const {
     return *new Tofino1ExpressionResolver(programInfo, executionState);
+}
+
+void Tofino1FlayStepper::initializeParserState(const IR::P4Parser &parser) {
+    // TODO: In Tofino blocks can have optional elements. How to support setting the parser error
+    // for that?
+
+    // Both parsers have 6 parameters.
+    // BUG_CHECK(parser.getApplyParameters()->parameters.size() == 6,
+    //           "Expected 6 parameters for parser %1%", parser);
+    const auto &parameters = parser.getApplyParameters()->parameters;
+
+    auto canonicalBlockName = getProgramInfo().getCanonicalBlockName(parser.name);
+    const auto *sixteenBitType = IR::Type_Bits::get(16);
+    if (canonicalBlockName == "IngressParserT") {
+        // If the parser has fewer than 4 parameters, which means it does not set the parser error
+        // within the parser block, we set the parser error directly in the global metadata.
+        constexpr int kParserMetadataIndex = 3;
+        if (parameters.size() > kParserMetadataIndex) {
+            // Initialize the parser error to be a symbolic variable.
+            const auto *metadataBlock =
+                parser.getApplyParameters()->parameters.at(kParserMetadataIndex);
+            auto *parserErrorVariable = new IR::Member(
+                sixteenBitType, new IR::PathExpression(metadataBlock->name), "parser_err");
+            auto parserErrorLabel =
+                parser.controlPlaneName() + "_" + metadataBlock->controlPlaneName() + "_parser_err";
+            getExecutionState().set(parserErrorVariable, ToolsVariables::getSymbolicVariable(
+                                                             sixteenBitType, parserErrorLabel));
+        } else {
+            const auto *parserErrorVar = new IR::Member(
+                sixteenBitType, new IR::PathExpression("*ig_intr_md_from_prsr"), "parser_err");
+            const IR::Expression *parserErrorValue =
+                new IR::SymbolicVariable(sixteenBitType, "ig_intr_md_from_prsr.parser_err");
+            getExecutionState().set(parserErrorVar, parserErrorValue);
+        }
+    } else if (canonicalBlockName == "EgressParserT") {
+        constexpr int kParserMetadataIndex = 4;
+        // If the parser has fewer than 5 parameters, which means it does not set the parser error
+        // within the parser block, we set the parser error directly in the global metadata.
+        if (parameters.size() > kParserMetadataIndex) {
+            // Initialize the parser error to be a symbolic variable.
+            const auto *metadataBlock =
+                parser.getApplyParameters()->parameters.at(kParserMetadataIndex);
+            auto *parserErrorVariable = new IR::Member(
+                sixteenBitType, new IR::PathExpression(metadataBlock->name), "parser_err");
+            auto parserErrorLabel =
+                parser.controlPlaneName() + "_" + metadataBlock->controlPlaneName() + "_parser_err";
+            getExecutionState().set(parserErrorVariable, ToolsVariables::getSymbolicVariable(
+                                                             sixteenBitType, parserErrorLabel));
+        } else {
+            const auto *parserErrorVar = new IR::Member(
+                sixteenBitType, new IR::PathExpression("*eg_intr_md_from_prsr"), "parser_err");
+            const IR::Expression *parserErrorValue =
+                new IR::SymbolicVariable(sixteenBitType, "eg_intr_md_from_prsr.parser_err");
+            getExecutionState().set(parserErrorVar, parserErrorValue);
+        }
+    } else {
+        BUG("Unexpected canonical block name %1% for parser %2%", canonicalBlockName, parser);
+    }
 }
 
 }  // namespace P4Tools::Flay::Tofino

--- a/targets/tofino/tofino1/stepper.h
+++ b/targets/tofino/tofino1/stepper.h
@@ -17,6 +17,8 @@ class Tofino1FlayStepper : public TofinoBaseFlayStepper {
     explicit Tofino1FlayStepper(const Tofino1ProgramInfo &programInfo,
                                 ExecutionState &executionState);
 
+    void initializeParserState(const IR::P4Parser &parser) override;
+
     Tofino1ExpressionResolver &createExpressionResolver(
         const ProgramInfo &programInfo, ExecutionState &executionState) const override;
 };


### PR DESCRIPTION
We currently do not model whether a parser error can happen. Make sure the parser error stays symbolic so that we do not accidentally remove expressions depending on it. 