### PR TITLE
Use ResolutionContext instead of a reference map.

### DIFF
--- a/core/control_plane/symbolic_state.h
+++ b/core/control_plane/symbolic_state.h
@@ -4,16 +4,13 @@
 #include "backends/p4tools/modules/flay/core/control_plane/control_plane_item.h"
 #include "backends/p4tools/modules/flay/core/control_plane/control_plane_objects.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 
 namespace P4Tools::Flay {
 
-class ControlPlaneStateInitializer : public Inspector {
- private:
-    /// The reference map to look up specific declarations.
-    std::reference_wrapper<const P4::ReferenceMap> _refMap;
-
+class ControlPlaneStateInitializer : public Inspector, protected P4::ResolutionContext {
  protected:
     /// The default control-plane constraints as defined by a target.
     ControlPlaneConstraints _defaultConstraints;
@@ -32,8 +29,7 @@ class ControlPlaneStateInitializer : public Inspector {
 
     /// Tries to build a table control plane entry from the P4 entry member of the table.
     /// @returns std::nullopt if an error occurs when doing this.
-    std::optional<TableEntrySet> initializeTableEntries(const IR::P4Table *table,
-                                                        const P4::ReferenceMap &refMap);
+    std::optional<TableEntrySet> initializeTableEntries(const IR::P4Table *table);
 
     /// Compute the constraints imposed by any entries defined for the table.
     static std::optional<ControlPlaneAssignmentSet> computeEntryAction(
@@ -42,14 +38,14 @@ class ControlPlaneStateInitializer : public Inspector {
 
     /// Compute the constraints imposed by the default action if the table is not configured.
     /// @returns std::nullopt if an error occurs.
-    static std::optional<ControlPlaneAssignmentSet> computeDefaultActionConstraints(
-        const IR::P4Table *table, const P4::ReferenceMap &refMap);
+    std::optional<ControlPlaneAssignmentSet> computeDefaultActionConstraints(
+        const IR::P4Table *table) const;
 
     /// Get the reference map.
     [[nodiscard]] const P4::ReferenceMap &refMap() const;
 
  public:
-    explicit ControlPlaneStateInitializer(const P4::ReferenceMap &refMap);
+    ControlPlaneStateInitializer();
 
     virtual std::optional<ControlPlaneConstraints> generateInitialControlPlaneConstraints(
         const IR::P4Program *program) = 0;

--- a/targets/bmv2/symbolic_state.h
+++ b/targets/bmv2/symbolic_state.h
@@ -2,8 +2,6 @@
 #define BACKENDS_P4TOOLS_MODULES_FLAY_TARGETS_BMV2_SYMBOLIC_STATE_H_
 
 #include "backends/p4tools/modules/flay/core/control_plane/symbolic_state.h"
-#include "frontends/common/resolveReferences/referenceMap.h"
-#include "ir/visitor.h"
 
 namespace P4Tools::Flay::V1Model {
 
@@ -13,8 +11,7 @@ class Bmv2ControlPlaneInitializer : public ControlPlaneStateInitializer {
                       ControlPlaneAssignmentSet &keySet) override;
 
  public:
-    explicit Bmv2ControlPlaneInitializer(const P4::ReferenceMap &refMap)
-        : ControlPlaneStateInitializer(refMap) {}
+    Bmv2ControlPlaneInitializer() = default;
 
     std::optional<ControlPlaneConstraints> generateInitialControlPlaneConstraints(
         const IR::P4Program *program) override;

--- a/targets/bmv2/target.cpp
+++ b/targets/bmv2/target.cpp
@@ -164,13 +164,9 @@ CompilerResultOrError V1ModelFlayTarget::runCompilerImpl(const CompilerOptions &
     P4::TypeMap typeMap;
     program = program->apply(mkPrivateMidEnd(options, &refMap, &typeMap));
 
-    // TODO: We only need this because P4Info does not contain information on default actions.
-    program->apply(P4::ResolveReferences(&refMap));
-
-    ASSIGN_OR_RETURN(
-        auto initialControlPlaneState,
-        Bmv2ControlPlaneInitializer(refMap).generateInitialControlPlaneConstraints(program),
-        std::nullopt);
+    ASSIGN_OR_RETURN(auto initialControlPlaneState,
+                     Bmv2ControlPlaneInitializer().generateInitialControlPlaneConstraints(program),
+                     std::nullopt);
 
     return {*new FlayCompilerResult{CompilerResult(*program), *originalProgram,
                                     p4runtimeApi.value(), initialControlPlaneState}};

--- a/targets/fpga/symbolic_state.h
+++ b/targets/fpga/symbolic_state.h
@@ -2,7 +2,6 @@
 #define BACKENDS_P4TOOLS_MODULES_FLAY_TARGETS_FPGA_SYMBOLIC_STATE_H_
 
 #include "backends/p4tools/modules/flay/core/control_plane/symbolic_state.h"
-#include "frontends/common/resolveReferences/referenceMap.h"
 
 namespace P4Tools::Flay::Fpga {
 
@@ -12,8 +11,7 @@ class FpgaControlPlaneInitializer : public ControlPlaneStateInitializer {
                       ControlPlaneAssignmentSet &keySet) override;
 
  public:
-    explicit FpgaControlPlaneInitializer(const P4::ReferenceMap &refMap)
-        : ControlPlaneStateInitializer(refMap) {}
+    FpgaControlPlaneInitializer() = default;
 
     std::optional<ControlPlaneConstraints> generateInitialControlPlaneConstraints(
         const IR::P4Program *program) override;

--- a/targets/fpga/target.cpp
+++ b/targets/fpga/target.cpp
@@ -65,13 +65,9 @@ CompilerResultOrError FpgaBaseFlayTarget::runCompilerImpl(const CompilerOptions 
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     program = program->apply(mkPrivateMidEnd(options, &refMap, &typeMap));
-    // TODO: We only need this because P4Info does not contain information on default actions.
-    program->apply(P4::ResolveReferences(&refMap));
-
-    ASSIGN_OR_RETURN(
-        auto initialControlPlaneState,
-        FpgaControlPlaneInitializer(refMap).generateInitialControlPlaneConstraints(program),
-        std::nullopt);
+    ASSIGN_OR_RETURN(auto initialControlPlaneState,
+                     FpgaControlPlaneInitializer().generateInitialControlPlaneConstraints(program),
+                     std::nullopt);
 
     return {*new FlayCompilerResult{CompilerResult(*program), *originalProgram,
                                     p4runtimeApi.value(), initialControlPlaneState}};

--- a/targets/tofino/symbolic_state.h
+++ b/targets/tofino/symbolic_state.h
@@ -2,7 +2,6 @@
 #define BACKENDS_P4TOOLS_MODULES_FLAY_TARGETS_TOFINO_SYMBOLIC_STATE_H_
 
 #include "backends/p4tools/modules/flay/core/control_plane/symbolic_state.h"
-#include "frontends/common/resolveReferences/referenceMap.h"
 
 namespace P4Tools::Flay::Tofino {
 
@@ -14,9 +13,13 @@ class TofinoControlPlaneInitializer : public ControlPlaneStateInitializer {
     bool preorder(const IR::P4Table *table) override;
     bool preorder(const IR::Declaration_Instance *declaration) override;
 
+    /// Check whether the table has an action-profile implementation and return the name of the
+    /// action profile if so.
+    std::optional<cstring> associateActionProfiles(
+        const IR::P4Table &table, ControlPlaneConstraints &_defaultConstraints) const;
+
  public:
-    explicit TofinoControlPlaneInitializer(const P4::ReferenceMap &refMap)
-        : ControlPlaneStateInitializer(refMap) {}
+    TofinoControlPlaneInitializer() = default;
 
     std::optional<ControlPlaneConstraints> generateInitialControlPlaneConstraints(
         const IR::P4Program *program) override;

--- a/targets/tofino/target.cpp
+++ b/targets/tofino/target.cpp
@@ -75,12 +75,10 @@ CompilerResultOrError TofinoBaseFlayTarget::runCompilerImpl(const CompilerOption
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     program = program->apply(mkPrivateMidEnd(options, &refMap, &typeMap));
-    // TODO: We only need this because P4Info does not contain information on default actions.
-    program->apply(P4::ResolveReferences(&refMap));
 
     ASSIGN_OR_RETURN(
         auto initialControlPlaneState,
-        TofinoControlPlaneInitializer(refMap).generateInitialControlPlaneConstraints(program),
+        TofinoControlPlaneInitializer().generateInitialControlPlaneConstraints(program),
         std::nullopt);
 
     return {*new FlayCompilerResult{CompilerResult(*program), *originalProgram,


### PR DESCRIPTION
Minor optimization while trying to fix the way we emit P4 programs. 