### PR TITLE
Scale processing of updates.

### DIFF
--- a/core/control_plane/control_plane_objects.h
+++ b/core/control_plane/control_plane_objects.h
@@ -25,6 +25,11 @@ const IR::SymbolicVariable *getDefaultActionVariable(cstring tableName);
 
 namespace P4::P4Tools::Flay {
 
+/// How many entries per table we can support before we fall back to making the entire table
+/// configuration symbolic.
+/// TODO: Consider making this an option?
+constexpr size_t kMaxEntriesPerTable = 50;
+
 /**************************************************************************************************
 TableMatchKeys
 **************************************************************************************************/

--- a/core/lib/incremental_analysis.h
+++ b/core/lib/incremental_analysis.h
@@ -114,10 +114,10 @@ class IncrementalAnalysis : public ICastable {
         ASSIGN_OR_RETURN(SymbolSet symbolSet, convertControlPlaneUpdate(controlPlaneUpdate),
                          std::nullopt);
         ASSIGN_OR_RETURN(bool changeNeeded, checkForSemanticsChange(symbolSet), std::nullopt);
+        printInfo("Change in semantics detected: %1%", changeNeeded ? "yes" : "no");
         if (!changeNeeded) {
-            return &program;
+            return std::optional{nullptr};
         }
-        printInfo("Change in semantics detected.");
 
         auto newProgram = specializeProgram(program);
         return newProgram;
@@ -130,6 +130,7 @@ class IncrementalAnalysis : public ICastable {
         const IR::P4Program &program,
         const std::vector<const ControlPlaneUpdate *> &controlPlaneUpdates) {
         SymbolSet symbolSet;
+        printInfo("Processing %s control plane updates.", controlPlaneUpdates.size());
         for (const auto &update : controlPlaneUpdates) {
             ASSIGN_OR_RETURN(SymbolSet updateSymbolSet, convertControlPlaneUpdate(*update),
                              std::nullopt);
@@ -137,10 +138,10 @@ class IncrementalAnalysis : public ICastable {
         }
         if (flayOptions().useSymbolSet()) {
             ASSIGN_OR_RETURN(bool changeNeeded, checkForSemanticsChange(symbolSet), std::nullopt);
+            printInfo("Change in semantics detected: %1%", changeNeeded ? "yes" : "no");
             if (!changeNeeded) {
-                return &program;
+                return std::optional{nullptr};
             }
-            printInfo("Change in semantics detected.");
         }
 
         return specializeProgram(program);

--- a/core/specialization/flay_service.cpp
+++ b/core/specialization/flay_service.cpp
@@ -72,9 +72,11 @@ int FlayServiceBase::processControlPlaneUpdate(const ControlPlaneUpdate &control
         if (!optProgram.has_value()) {
             return EXIT_FAILURE;
         }
-        optimizedProg = optProgram.value();
+        if (optProgram.value() != nullptr) {
+            optimizedProg = optProgram.value();
+            _optimizedProgram = optimizedProg;
+        }
     }
-    _optimizedProgram = optimizedProg;
     return EXIT_SUCCESS;
 }
 
@@ -88,9 +90,11 @@ int FlayServiceBase::processControlPlaneUpdate(
         if (!optProgram.has_value()) {
             return EXIT_FAILURE;
         }
-        optimizedProg = optProgram.value();
+        if (optProgram.value() != nullptr) {
+            optimizedProg = optProgram.value();
+            _optimizedProgram = optimizedProg;
+        }
     }
-    _optimizedProgram = optimizedProg;
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
- Stop optimizing once update counts hits >100 for a single table. 
- Make sure we only optimize the program once it has actually changed (and return the optimized version)